### PR TITLE
Fix failing PHP codesniffer tests

### DIFF
--- a/src/Storage/Writable/Maildir.php
+++ b/src/Storage/Writable/Maildir.php
@@ -101,7 +101,7 @@ class Maildir extends Folder\Maildir implements WritableInterface
      * may be used as parent or which chars may be used in the folder name
      *
      * @param   string                           $name         global name of folder, local name if $parentFolder is set
-     * @param   string|\Laminas\Mail\Storage\Folder $parentFolder parent folder for new folder, else root folder is parent
+     * @param   string|\Laminas\Mail\Storage\Folder $parentFolder parent of new folder, else root folder is parent
      * @throws \Laminas\Mail\Storage\Exception\RuntimeException
      * @return  string only used internally (new created maildir)
      */

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -87,8 +87,14 @@ class SendmailTest extends TestCase
         $this->assertEquals('This is only a test.', trim($this->message));
         $this->assertNotContains("To: Laminas DevTeam <api-tools-devteam@zend.com>\n", $this->additional_headers);
         $this->assertContains("Cc: matthew@zend.com\n", $this->additional_headers);
-        $this->assertContains("Bcc: \"CR-Team, Laminas Project\" <api-tools-crteam@lists.zend.com>\n", $this->additional_headers);
-        $this->assertContains("From: api-tools-devteam@zend.com,\n Matthew <matthew@zend.com>\n", $this->additional_headers);
+        $this->assertContains(
+            "Bcc: \"CR-Team, Laminas Project\" <api-tools-crteam@lists.zend.com>\n",
+            $this->additional_headers
+        );
+        $this->assertContains(
+            "From: api-tools-devteam@zend.com,\n Matthew <matthew@zend.com>\n",
+            $this->additional_headers
+        );
         $this->assertContains("X-Foo-Bar: Matthew\n", $this->additional_headers);
         $this->assertContains("Sender: Ralph Schindler <ralph.schindler@zend.com>\n", $this->additional_headers);
         $this->assertEquals('-R hdrs -f\'ralph.schindler@zend.com\'', $this->additional_parameters);
@@ -108,7 +114,10 @@ class SendmailTest extends TestCase
         $this->assertEquals('This is only a test.', trim($this->message));
         $this->assertContains("To: Laminas DevTeam <api-tools-devteam@zend.com>\r\n", $this->additional_headers);
         $this->assertContains("Cc: matthew@zend.com\r\n", $this->additional_headers);
-        $this->assertContains("Bcc: \"CR-Team, Laminas Project\" <api-tools-crteam@lists.zend.com>\r\n", $this->additional_headers);
+        $this->assertContains(
+            "Bcc: \"CR-Team, Laminas Project\" <api-tools-crteam@lists.zend.com>\r\n",
+            $this->additional_headers
+        );
         $this->assertContains(
             "From: api-tools-devteam@zend.com,\r\n Matthew <matthew@zend.com>\r\n",
             $this->additional_headers


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Current build on Travis CI is failing due to complaints raised by PHP codesniffer. This pull request solves those.