### PR TITLE
Add current PHP versions to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,18 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,7 @@ matrix:
         - DEPS=latest
     - php: 7.3
       env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
         - DEPS=latest
-    - php: 7.4
-      env:
-        - DEPS=lowest
     - php: 7.4
       env:
         - DEPS=latest


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
PHP version constraint in `composer.json` permit usage with PHP versions 7.3 & 7.4, but these versions do not run the testsuite via Travis CI. Additionally, it seems sensible to run codesniffer & coveralls on the latest support version.