### PR TITLE
Transport\InMemory: no messages could have been sent, fix return type

### DIFF
--- a/src/Transport/InMemory.php
+++ b/src/Transport/InMemory.php
@@ -20,7 +20,7 @@ use Laminas\Mail\Message;
 class InMemory implements TransportInterface
 {
     /**
-     * @var Message
+     * @var null|Message
      */
     protected $lastMessage;
 
@@ -37,7 +37,7 @@ class InMemory implements TransportInterface
     /**
      * Get the last message sent.
      *
-     * @return Message
+     * @return null|Message
      */
     public function getLastMessage()
     {

--- a/test/Transport/InMemoryTest.php
+++ b/test/Transport/InMemoryTest.php
@@ -42,6 +42,8 @@ class InMemoryTest extends TestCase
         $message = $this->getMessage();
         $transport = new InMemory();
 
+        $this->assertNull($transport->getLastMessage());
+
         $transport->send($message);
 
         $this->assertSame($message, $transport->getLastMessage());


### PR DESCRIPTION
It may happen that no messages have been sent, so the return type could be null as well.