### PR TITLE
Use link to ZF tracker

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -344,7 +344,7 @@ class Smtp extends AbstractProtocol
     public function rset()
     {
         $this->_send('RSET');
-        // MS ESMTP doesn't follow RFC, see [Laminas-1377]
+        // MS ESMTP doesn't follow RFC, see https://zendframework.com/issues/browse/ZF-1377
         $this->_expect([250, 220]);
 
         $this->mail = false;


### PR DESCRIPTION
I was going over diffs to see what changed zend-mail 2.10.0 to laminas 2.10.1 and noticed a bad replace.

This fixes bad replace ZF->Laminas by using a link instead