### PR TITLE
Fix AddressList toString method to quote semicolon

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -135,7 +135,9 @@ abstract class AbstractAddressList implements HeaderInterface
             $email = $address->getEmail();
             $name  = $address->getName();
 
-            if (! empty($name) && false !== strstr($name, ',')) {
+            // quote $name if value requires so
+            if (! empty($name) && (false !== strpos($name, ',') || false !== strpos($name, ';'))) {
+                // FIXME: what if name contains double quote?
                 $name = sprintf('"%s"', $name);
             }
 
@@ -241,7 +243,7 @@ abstract class AbstractAddressList implements HeaderInterface
      * Supposed to be private, protected as a workaround for PHP bug 68194
      *
      * @param string $value
-     * @return void
+     * @return string
      */
     protected static function stripComments($value)
     {


### PR DESCRIPTION
This is port of https://github.com/zendframework/zend-mail/pull/230 fixing regression from https://github.com/zendframework/zend-mail/pull/147

Fixes https://github.com/laminas/laminas-mail/issues/14

----

Certain input of `AddressList` headers, cannot be converted to string and back to header object because of incorrect quoting:

```
From: "Foo;" <root@example.com>
```
gets incorrectly converted as


```
From: Foo; <root@example.com>
```

but `;` is address separator, so it needs to be quoted:

```
From: "Foo;" <root@example.com>
```

The problem I discovered internally when using `Storage\Message` with `Headers` input, therefore testing that method is included in the unit test:

```php
$message = new Message(['headers' => new Headers(), 'content' => (string)$body]);

// Mime\Decode::splitMessage calls toString on headers object which creates invalid result:
if ($message instanceof Headers) {
    $message = $message->toString();
}
```