### PR TITLE
Add option novalidatecert to connect(); closes #63

### DIFF
--- a/docs/book/read.md
+++ b/docs/book/read.md
@@ -117,6 +117,10 @@ $mail = new Pop3([
 ]);
 ```
 
+If you are connecting to a mail server with a self-signed certificate and want to
+skip the SSL verification, you can also pass an additional argument `novalidatecert` 
+with the value `true`.
+
 Both constructors throw `Laminas\Mail\Exception` or `Laminas\Mail\Protocol\Exception`
 (extends `Laminas\Mail\Exception`) for connection errors, depending on the type of
 error encountered.

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -20,12 +20,6 @@ class Imap
     const TIMEOUT_CONNECTION = 30;
 
     /**
-     * If set to true, do not validate the SSL certificate
-     * @var null|bool
-     */
-    protected $novalidatecert;
-
-    /**
      * socket to imap server
      * @var resource|null
      */
@@ -40,15 +34,15 @@ class Imap
     /**
      * Public constructor
      *
-     * @param  string   $host            hostname or IP address of IMAP server, if given connect() is called
-     * @param  int|null $port            port of IMAP server, null for default (143 or 993 for ssl)
-     * @param  bool     $ssl             use ssl? 'SSL', 'TLS' or false
-     * @param  bool     $novalidatecert  set to true to skip SSL certificate validation
+     * @param  string   $host           hostname or IP address of IMAP server, if given connect() is called
+     * @param  int|null $port           port of IMAP server, null for default (143 or 993 for ssl)
+     * @param  bool     $ssl            use ssl? 'SSL', 'TLS' or false
+     * @param  bool     $novalidatecert set to true to skip SSL certificate validation
      * @throws \Laminas\Mail\Protocol\Exception\ExceptionInterface
      */
     public function __construct($host = '', $port = null, $ssl = false, $novalidatecert = false)
     {
-        $this->novalidatecert = $novalidatecert;
+        $this->setNoValidateCert($novalidatecert);
 
         if ($host) {
             $this->connect($host, $port, $ssl);
@@ -61,14 +55,6 @@ class Imap
     public function __destruct()
     {
         $this->logout();
-    }
-
-    public function setNoValidateCert($novalidatecert)
-    {
-
-        if (is_bool($novalidatecert)) {
-            $this->novalidatecert = $novalidatecert;
-        }
     }
 
     /**
@@ -106,7 +92,7 @@ class Imap
 
         $socket_options = [];
 
-        if ($this->novalidatecert) {
+        if (!$this->validateCert()) {
             $socket_options = [
                 'ssl' => [
                     'verify_peer_name' => false,

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -84,7 +84,7 @@ class Imap
                 }
         }
 
-        $this->setSocket($host, $port);
+        $this->setupSocket($host, $port);
 
         if (! $this->assumedNextLine('* OK')) {
             throw new Exception\RuntimeException('host doesn\'t allow connection');

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -20,12 +20,6 @@ class Imap
     const TIMEOUT_CONNECTION = 30;
 
     /**
-     * socket to imap server
-     * @var resource|null
-     */
-    protected $socket;
-
-    /**
      * counter for request tag
      * @var int
      */
@@ -90,36 +84,7 @@ class Imap
                 }
         }
 
-        $socket_options = [];
-
-        if (!$this->validateCert()) {
-            $socket_options = [
-                'ssl' => [
-                    'verify_peer_name' => false,
-                    'verify_peer'      => false,
-                ]
-            ];
-        }
-
-        $socket_context = stream_context_create($socket_options);
-
-        ErrorHandler::start();
-        $this->socket = stream_socket_client(
-            $host . ":" . $port,
-            $errno,
-            $errstr,
-            self::TIMEOUT_CONNECTION,
-            STREAM_CLIENT_CONNECT,
-            $socket_context
-        );
-
-        $error = ErrorHandler::stop();
-        if (! $this->socket) {
-            throw new Exception\RuntimeException(sprintf(
-                'cannot connect to host %s',
-                ($error ? sprintf('; error = %s (errno = %d )', $error->getMessage(), $error->getCode()) : '')
-            ), 0, $error);
-        }
+        $this->setSocket($host, $port);
 
         if (! $this->assumedNextLine('* OK')) {
             throw new Exception\RuntimeException('host doesn\'t allow connection');

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -89,7 +89,7 @@ class Pop3
                 }
         }
 
-        $this->setSocket($host, $port);
+        $this->setupSocket($host, $port);
 
         $welcome = $this->readResponse();
 

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -26,12 +26,6 @@ class Pop3
     public $hasTop = null;
 
     /**
-     * socket to pop3
-     * @var null|resource
-     */
-    protected $socket;
-
-    /**
      * greeting timestamp for apop
      * @var null|string
      */
@@ -95,36 +89,7 @@ class Pop3
                 }
         }
 
-        $socket_options = [];
-
-        if (!$this->validateCert()) {
-            $socket_options = [
-                'ssl' => [
-                    'verify_peer_name' => false,
-                    'verify_peer'      => false,
-                ]
-            ];
-        }
-
-        $socket_context = stream_context_create($socket_options);
-
-        ErrorHandler::start();
-        $this->socket = stream_socket_client(
-            $host . ":" . $port,
-            $errno,
-            $errstr,
-            self::TIMEOUT_CONNECTION,
-            STREAM_CLIENT_CONNECT,
-            $socket_context
-        );
-
-        $error = ErrorHandler::stop();
-        if (! $this->socket) {
-            throw new Exception\RuntimeException(sprintf(
-                'cannot connect to host %s',
-                ($error ? sprintf('; error = %s (errno = %d )', $error->getMessage(), $error->getCode()) : '')
-            ), 0, $error);
-        }
+        $this->setSocket($host, $port);
 
         $welcome = $this->readResponse();
 

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -26,12 +26,6 @@ class Pop3
     public $hasTop = null;
 
     /**
-     * If set to true, do not validate the SSL certificate
-     * @var null|bool
-     */
-    protected $novalidatecert;
-
-    /**
      * socket to pop3
      * @var null|resource
      */
@@ -46,14 +40,14 @@ class Pop3
     /**
      * Public constructor
      *
-     * @param  string      $host            hostname or IP address of POP3 server, if given connect() is called
-     * @param  int|null    $port            port of POP3 server, null for default (110 or 995 for ssl)
-     * @param  bool|string $ssl             use ssl? 'SSL', 'TLS' or false
-     * @param  bool        $novalidatecert  set to true to skip SSL certificate validation
+     * @param  string      $host           hostname or IP address of POP3 server, if given connect() is called
+     * @param  int|null    $port           port of POP3 server, null for default (110 or 995 for ssl)
+     * @param  bool|string $ssl            use ssl? 'SSL', 'TLS' or false
+     * @param  bool        $novalidatecert set to true to skip SSL certificate validation
      */
     public function __construct($host = '', $port = null, $ssl = false, $novalidatecert = false)
     {
-        $this->novalidatecert = $novalidatecert;
+        $this->setNoValidateCert($novalidatecert);
 
         if ($host) {
             $this->connect($host, $port, $ssl);
@@ -66,14 +60,6 @@ class Pop3
     public function __destruct()
     {
         $this->logout();
-    }
-
-    public function setNoValidateCert($novalidatecert)
-    {
-
-        if (is_bool($novalidatecert)) {
-            $this->novalidatecert = $novalidatecert;
-        }
     }
 
     /**
@@ -111,7 +97,7 @@ class Pop3
 
         $socket_options = [];
 
-        if ($this->novalidatecert) {
+        if (!$this->validateCert()) {
             $socket_options = [
                 'ssl' => [
                     'verify_peer_name' => false,

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -94,8 +94,8 @@ trait ProtocolTrait
             STREAM_CLIENT_CONNECT,
             stream_context_create($this->prepareSocketOptions())
         );
-
         $error = ErrorHandler::stop();
+
         if (! $this->socket) {
             throw new Exception\RuntimeException(sprintf(
                 'cannot connect to host %s',

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -81,10 +81,8 @@ trait ProtocolTrait
      *
      * @return void
      */
-    protected function setSocket($host, $port)
+    protected function setupSocket($host, $port)
     {
-        $socketOptions = [];
-
         ErrorHandler::start();
         $this->socket = stream_socket_client(
             $host . ":" . $port,

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -13,6 +13,12 @@ namespace Laminas\Mail\Protocol;
  */
 trait ProtocolTrait
 {
+    /**
+     * If set to true, do not validate the SSL certificate
+     * @var null|bool
+     */
+    protected $novalidatecert;
+
     public function getCryptoMethod()
     {
         // Allow the best TLS version(s) we can
@@ -26,5 +32,28 @@ trait ProtocolTrait
         }
 
         return $cryptoMethod;
+    }
+
+    /**
+     * Do not validate SSL certificate
+     *
+     * @param bool $novalidatecert Set to true to disable certificate validation
+     *
+     * @return Imap
+     */
+    public function setNoValidateCert(bool $novalidatecert)
+    {
+        $this->novalidatecert = $novalidatecert;
+        return $this;
+    }
+
+    /**
+     * Should we validate SSL certificate?
+     *
+     * @return bool
+     */
+    public function validateCert()
+    {
+        return !$this->novalidatecert;
     }
 }

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -62,7 +62,7 @@ trait ProtocolTrait
      *
      * @return array
      */
-    protected function prepareSocketOptions()
+    private function prepareSocketOptions()
     {
         return $this->novalidatecert
             ? [

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -14,12 +14,6 @@ namespace Laminas\Mail\Protocol;
 trait ProtocolTrait
 {
     /**
-     * socket to mail server
-     * @var resource|null
-     */
-    protected $socket;
-
-    /**
      * If set to true, do not validate the SSL certificate
      * @var null|bool
      */

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -64,6 +64,22 @@ trait ProtocolTrait
     }
 
     /**
+     * Prepare socket options
+     *
+     * @return array
+     */
+    protected function prepareSocketOptions()
+    {
+        return $this->novalidatecert
+            ? [
+                'ssl' => [
+                    'verify_peer_name' => false,
+                    'verify_peer'      => false,
+                ]
+            ] : [];
+    }
+
+    /**
      * Setup connection socket
      *
      * @param  string   $host hostname or IP address of IMAP server
@@ -75,17 +91,6 @@ trait ProtocolTrait
     {
         $socketOptions = [];
 
-        if (!$this->validateCert()) {
-            $socketOptions = [
-                'ssl' => [
-                    'verify_peer_name' => false,
-                    'verify_peer'      => false,
-                ]
-            ];
-        }
-
-        $socketContext = stream_context_create($socketOptions);
-
         ErrorHandler::start();
         $this->socket = stream_socket_client(
             $host . ":" . $port,
@@ -93,7 +98,7 @@ trait ProtocolTrait
             $errstr,
             self::TIMEOUT_CONNECTION,
             STREAM_CLIENT_CONNECT,
-            $socketContext
+            stream_context_create($this->prepareSocketOptions())
         );
 
         $error = ErrorHandler::stop();

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -54,7 +54,7 @@ trait ProtocolTrait
      */
     public function validateCert()
     {
-        return !$this->novalidatecert;
+        return ! $this->novalidatecert;
     }
 
     /**

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -215,7 +215,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
         $this->protocol = new Protocol\Imap();
 
         if (isset($params->novalidatecert)) {
-            $this->protocol->setNoValidateCert(true);
+            $this->protocol->setNoValidateCert((bool)$params->novalidatecert);
         }
 
         $this->protocol->connect($host, $port, $ssl);

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -213,6 +213,11 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
         $ssl      = isset($params->ssl) ? $params->ssl : false;
 
         $this->protocol = new Protocol\Imap();
+
+        if (isset($params->novalidatecert)) {
+            $this->protocol->setNoValidateCert(true);
+        }
+
         $this->protocol->connect($host, $port, $ssl);
         if (! $this->protocol->login($params->user, $password)) {
             throw new Exception\RuntimeException('cannot login, user or password wrong');

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -146,6 +146,11 @@ class Pop3 extends AbstractStorage
         $ssl      = isset($params->ssl) ? $params->ssl : false;
 
         $this->protocol = new Protocol\Pop3();
+
+        if (isset($params->novalidatecert)) {
+            $this->protocol->setNoValidateCert($params->novalidatecert);
+        }
+
         $this->protocol->connect($host, $port, $ssl);
         $this->protocol->login($params->user, $password);
     }

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -148,7 +148,7 @@ class Pop3 extends AbstractStorage
         $this->protocol = new Protocol\Pop3();
 
         if (isset($params->novalidatecert)) {
-            $this->protocol->setNoValidateCert($params->novalidatecert);
+            $this->protocol->setNoValidateCert((bool)$params->novalidatecert);
         }
 
         $this->protocol->connect($host, $port, $ssl);

--- a/test/Storage/ImapTest.php
+++ b/test/Storage/ImapTest.php
@@ -130,6 +130,17 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
+    public function testConnectSelfSignedSSL()
+    {
+        if (! getenv('TESTS_LAMINAS_MAIL_IMAP_SSL')) {
+            return;
+        }
+
+        $this->params['ssl'] = 'SSL';
+        $this->params['novalidatecert'] = true;
+        new Storage\Imap($this->params);
+    }
+
     public function testInvalidService()
     {
         $this->params['port'] = getenv('TESTS_LAMINAS_MAIL_IMAP_INVALID_PORT');

--- a/test/Storage/Pop3Test.php
+++ b/test/Storage/Pop3Test.php
@@ -138,6 +138,18 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
+    public function testConnectSelfSignedSSL()
+    {
+        if (! getenv('TESTS_LAMINAS_MAIL_POP3_SSL')) {
+            return;
+        }
+
+        $this->params['ssl'] = 'SSL';
+        $this->params['novalidatecert'] = true;
+
+        new Storage\Pop3($this->params);
+    }
+
     public function testInvalidService()
     {
         $this->params['port'] = getenv('TESTS_LAMINAS_MAIL_POP3_INVALID_PORT');


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Allow connection with self signed SSL certificates; see #63; port of existing https://github.com/zendframework/zend-mail/pull/247.