### PR TITLE
Fix E_NOTICE on undefined $socket property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#95](https://github.com/laminas/laminas-mail/pull/95) adds the methods `setHeaderLocator(Laminas\Mail\Header\HeaderLocatorInterface $locator)` and `getHeaderLocator(): Laminas\Mail\Header\HeaderLocatorInterface` to the `Laminas\Mail\Headers` implementation. Users are encouraged to use these when providing custom header implementations in order to prepare for a 3.0 release.  **The value of `getHeaderLocator()` will now be used as the default mechanism for resolving header names to header classes.**
 
-- [#94](https://github.com/laminas/laminas-mail/pull/94) adds the "novalidatecert" option for POP3 and IMAP connections. When toggled true, you can connect to servers using self-signed certificates.
+- [#94](https://github.com/laminas/laminas-mail/pull/94) and [#99](https://github.com/laminas/laminas-mail/pull/99) add the "novalidatecert" option for each of the POP3, IMAP, and SMTP protocol implementations. When toggled true, you can connect to servers using self-signed certificates.
 
 ### Changed
 
 - [#95](https://github.com/laminas/laminas-mail/pull/95) bumps the minimum supported PHP version to 7.1.
 
 ### Deprecated
+
+- [#99](https://github.com/laminas/laminas-mail/pull/99) deprecates the `Laminas\Mail\Protocol\AbstractProtocol::_connect()` method, as it is no longer used internally.
 
 - [#95](https://github.com/laminas/laminas-mail/pull/95) deprecates `Laminas\Mail\Header\HeaderLoader` in favor of the new `Laminas\Mail\Header\HeaderLocator` class. The class will be removed in version 3.0.0.
 

--- a/src/Protocol/AbstractProtocol.php
+++ b/src/Protocol/AbstractProtocol.php
@@ -197,7 +197,7 @@ abstract class AbstractProtocol
     protected function _connect($remote)
     {
         // @codingStandardsIgnoreEnd
-        if (!preg_match('/^(?<host>.*):(?<port>\d+)$/', $remote, $matches)) {
+        if (! preg_match('/^(?<host>.*):(?<port>\d+)$/', $remote, $matches)) {
             throw new Exception\RuntimeException(sprintf('Invalid remote: %s', $remote));
         }
 

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -18,6 +18,11 @@ class Imap
     const TIMEOUT_CONNECTION = 30;
 
     /**
+     * @var null|resource
+     */
+    protected $socket;
+
+    /**
      * counter for request tag
      * @var int
      */
@@ -60,6 +65,7 @@ class Imap
      */
     public function connect($host, $port = null, $ssl = false)
     {
+        $transport = 'tcp';
         $isTls = false;
 
         if ($ssl) {
@@ -68,7 +74,7 @@ class Imap
 
         switch ($ssl) {
             case 'ssl':
-                $host = 'ssl://' . $host;
+                $transport = 'ssl';
                 if (! $port) {
                     $port = 993;
                 }
@@ -82,7 +88,7 @@ class Imap
                 }
         }
 
-        $this->setupSocket($host, $port, self::TIMEOUT_CONNECTION);
+        $this->socket = $this->setupSocket($transport, $host, $port, self::TIMEOUT_CONNECTION);
 
         if (! $this->assumedNextLine('* OK')) {
             throw new Exception\RuntimeException('host doesn\'t allow connection');

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -26,6 +26,11 @@ class Pop3
     public $hasTop = null;
 
     /**
+     * @var null|resource
+     */
+    protected $socket;
+
+    /**
      * greeting timestamp for apop
      * @var null|string
      */
@@ -67,6 +72,7 @@ class Pop3
      */
     public function connect($host, $port = null, $ssl = false)
     {
+        $transport = 'tcp';
         $isTls = false;
 
         if ($ssl) {
@@ -75,7 +81,7 @@ class Pop3
 
         switch ($ssl) {
             case 'ssl':
-                $host = 'ssl://' . $host;
+                $transport = 'ssl';
                 if (! $port) {
                     $port = 995;
                 }
@@ -89,7 +95,7 @@ class Pop3
                 }
         }
 
-        $this->setupSocket($host, $port, self::TIMEOUT_CONNECTION);
+        $this->socket = $this->setupSocket($transport, $host, $port, self::TIMEOUT_CONNECTION);
 
         $welcome = $this->readResponse();
 

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -20,11 +20,11 @@ trait ProtocolTrait
      * @var null|bool
      */
     protected $novalidatecert;
-    
-    /**	
-     * Socket to server	
-     * @var resource|null	
-     */	
+
+    /**
+     * Socket to server
+     * @var resource|null
+     */
     protected $socket;
 
     public function getCryptoMethod()

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -20,6 +20,12 @@ trait ProtocolTrait
      * @var null|bool
      */
     protected $novalidatecert;
+    
+    /**	
+     * Socket to server	
+     * @var resource|null	
+     */	
+    protected $socket;
 
     public function getCryptoMethod()
     {

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -16,8 +16,6 @@ namespace Laminas\Mail\Protocol;
  */
 class Smtp extends AbstractProtocol
 {
-    use ProtocolTrait;
-
     /**
      * The transport method for the socket
      *

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -16,6 +16,8 @@ namespace Laminas\Mail\Protocol;
  */
 class Smtp extends AbstractProtocol
 {
+    use ProtocolTrait;
+
     /**
      * The transport method for the socket
      *
@@ -150,6 +152,10 @@ class Smtp extends AbstractProtocol
             }
         }
 
+        if (array_key_exists('novalidatecert', $config)) {
+            $this->setNoValidateCert($config['novalidatecert']);
+        }
+
         parent::__construct($host, $port);
     }
 
@@ -181,9 +187,14 @@ class Smtp extends AbstractProtocol
      */
     public function connect()
     {
-        return $this->_connect($this->transport . '://' . $this->host . ':' . $this->port);
+        $this->socket = $this->setupSocket(
+            $this->transport,
+            $this->host,
+            $this->port,
+            self::TIMEOUT_CONNECTION
+        );
+        return true;
     }
-
 
     /**
      * Initiate HELO/EHLO sequence and set flag to indicate valid smtp session


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I am working with current state of develop branch and code is generating some E_NOTICE.

To reproduce :
 - create a protocol instance *without* initializing the connection,
 - destruct this protocol instance.
This is not a common use case, so I only experiencing it in an automated test suite.

Declaring the property `$socket` on `Laminas\Mail\Protocol\ProtocolTrait` should fix this issue.

```
Error E_NOTICE in /var/glpi/tests/imap/Toolbox.php on line 105, generated by file /var/glpi/vendor/laminas/laminas-mail/src/Protocol/Imap.php on line 411:
Undefined property: Laminas\Mail\Protocol\Imap::$socket
```
```
Error E_NOTICE in /var/glpi/tests/imap/Toolbox.php on line 105, generated by file /var/glpi/vendor/laminas/laminas-mail/src/Protocol/Pop3.php on line 194:
Undefined property: Laminas\Mail\Protocol\Pop3::$socket
```