### PR TITLE
Fixes #34 replace call_user_func* with self invoked function

### DIFF
--- a/src/Transport/File.php
+++ b/src/Transport/File.php
@@ -70,7 +70,7 @@ class File implements TransportInterface
     public function send(Message $message)
     {
         $options  = $this->options;
-        $filename = call_user_func($options->getCallback(), $this);
+        $filename = $options->getCallback()($this);
         $file     = $options->getPath() . DIRECTORY_SEPARATOR . $filename;
         $email    = $message->toString();
 

--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -133,7 +133,7 @@ class Sendmail implements TransportInterface
             $headers = str_replace("\r\n", "\n", $headers);
         }
 
-        call_user_func($this->callable, $to, $subject, $body, $headers, $params);
+        ($this->callable)($to, $subject, $body, $headers, $params);
     }
 
     /**

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -118,7 +118,7 @@ class AddressListHeaderTest extends TestCase
     public function testDeserializationFromString($headerLine, $class)
     {
         $callback = sprintf('%s::fromString', $class);
-        $header   = call_user_func($callback, $headerLine);
+        $header   = $callback($headerLine);
         $this->assertInstanceOf($class, $header);
         $list = $header->getAddressList();
         $this->assertEquals(4, count($list));
@@ -175,7 +175,7 @@ class AddressListHeaderTest extends TestCase
     public function testAllowsNoWhitespaceBetweenHeaderAndValue($headerLine, $class)
     {
         $callback = sprintf('%s::fromString', $class);
-        $header   = call_user_func($callback, $headerLine);
+        $header   = $callback($headerLine);
         $this->assertInstanceOf($class, $header);
         $list = $header->getAddressList();
         $this->assertEquals(4, count($list));

--- a/test/Transport/FileOptionsTest.php
+++ b/test/Transport/FileOptionsTest.php
@@ -35,7 +35,7 @@ class FileOptionsTest extends TestCase
     {
         $callback = $this->options->getCallback();
         $this->assertInternalType('callable', $callback);
-        $test     = call_user_func($callback, '');
+        $test     = $callback('');
         $this->assertRegExp('#^LaminasMail_\d+_\d+\.eml$#', $test);
     }
 


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

As requirement already upped to php ^7.1, I recreate PR https://github.com/zendframework/zend-mail/pull/200 Fixes https://github.com/laminas/laminas-mail/issues/34

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
