### PR TITLE
fix IMAP constructor annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#102](https://github.com/laminas/laminas-mail/pull/102) corrects a parameter typehint and a return type within the Protocol\Imap subcomponent to correctly detail what they allow.
 
 ### Deprecated
 

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -31,10 +31,10 @@ class Imap
     /**
      * Public constructor
      *
-     * @param  string   $host           hostname or IP address of IMAP server, if given connect() is called
-     * @param  int|null $port           port of IMAP server, null for default (143 or 993 for ssl)
-     * @param  bool     $ssl            use ssl? 'SSL', 'TLS' or false
-     * @param  bool     $novalidatecert set to true to skip SSL certificate validation
+     * @param  string       $host           hostname or IP address of IMAP server, if given connect() is called
+     * @param  int|null     $port           port of IMAP server, null for default (143 or 993 for ssl)
+     * @param  string|bool  $ssl            use ssl? 'SSL', 'TLS' or false
+     * @param  bool         $novalidatecert set to true to skip SSL certificate validation
      * @throws \Laminas\Mail\Protocol\Exception\ExceptionInterface
      */
     public function __construct($host = '', $port = null, $ssl = false, $novalidatecert = false)
@@ -61,7 +61,7 @@ class Imap
      * @param  int|null    $port  of IMAP server, default is 143 (993 for ssl)
      * @param  string|bool $ssl   use 'SSL', 'TLS' or false
      * @throws Exception\RuntimeException
-     * @return string welcome message
+     * @return void
      */
     public function connect($host, $port = null, $ssl = false)
     {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Tell us about why this change is necessary:

- Are you adding documentation?
Yes. The annotations were incorrect, making PhpStan complain.

