### PR TITLE
Fixes #19 Fixes #72 duplicate subject header on windows

### DIFF
--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -222,12 +222,7 @@ class Sendmail implements TransportInterface
      */
     protected function prepareHeaders(Mail\Message $message)
     {
-        // On Windows, simply return verbatim
-        if ($this->isWindowsOs()) {
-            return $message->getHeaders()->toString();
-        }
-
-        // On *nix platforms, strip the "to" header
+        // Strip the "to" and "subject" headers
         $headers = clone $message->getHeaders();
         $headers->removeHeader('To');
         $headers->removeHeader('Subject');

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -73,7 +73,7 @@ class SendmailTest extends TestCase
         return $message;
     }
 
-    public function isWindows()
+    private function isWindows()
     {
         return $this->operating_system === 'WIN';
     }
@@ -263,12 +263,10 @@ class SendmailTest extends TestCase
     }
 
     /**
-     * @see @see https://github.com/laminas/laminas-mail/issues/19
+     * @see https://github.com/laminas/laminas-mail/issues/19
      */
     public function testHeadersToAndSubjectAreNotDuplicated()
     {
-        $lineBreak = $this->isWindows() ? "\r\n" : "\n";
-
         $message = new Message();
         $message
             ->addTo('matthew@example.org')
@@ -282,6 +280,6 @@ class SendmailTest extends TestCase
         $this->assertEquals('Greetings and Salutations!', $this->subject);
 
         $this->assertNotRegExp('/^To: matthew\@example\.org$/m', $this->additional_headers);
-        $this->assertNotRegExp('/^Subject: Greetings and Salutations\!$/m', $this->additional_headers);
+        $this->assertNotRegExp('/^Subject: Greetings and Salutations!$/m', $this->additional_headers);
     }
 }

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -281,13 +281,7 @@ class SendmailTest extends TestCase
         $this->assertEquals('matthew@example.org', $this->to);
         $this->assertEquals('Greetings and Salutations!', $this->subject);
 
-        $this->assertNotContains(
-            'To: matthew@example.org, matthew@example.org' . $lineBreak,
-            $this->additional_headers
-        );
-        $this->assertNotContains(
-            'Subject: Greetings and Salutations!, Greetings and Salutations!' . $lineBreak,
-            $this->additional_headers
-        );
+        $this->assertNotRegExp('/^To: matthew\@example\.org$/m', $this->additional_headers);
+        $this->assertNotRegExp('/^Subject: Greetings and Salutations\!$/m', $this->additional_headers);
     }
 }

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -28,6 +28,7 @@ class SendmailTest extends TestCase
     public $message;
     public $additional_headers;
     public $additional_parameters;
+    public $operating_system;
 
     public function setUp()
     {
@@ -72,9 +73,14 @@ class SendmailTest extends TestCase
         return $message;
     }
 
+    public function isWindows()
+    {
+        return $this->operating_system === 'WIN';
+    }
+
     public function testReceivesMailArtifactsOnUnixSystems()
     {
-        if ($this->operating_system == 'WIN') {
+        if ($this->isWindows()) {
             $this->markTestSkipped('This test is *nix-specific');
         }
 
@@ -96,7 +102,7 @@ class SendmailTest extends TestCase
 
     public function testReceivesMailArtifactsOnWindowsSystems()
     {
-        if ($this->operating_system != 'WIN') {
+        if (! $this->isWindows()) {
             $this->markTestSkipped('This test is Windows-specific');
         }
 
@@ -120,7 +126,7 @@ class SendmailTest extends TestCase
 
     public function testLinesStartingWithFullStopsArePreparedProperlyForWindows()
     {
-        if ($this->operating_system != 'WIN') {
+        if (! $this->isWindows()) {
             $this->markTestSkipped('This test is Windows-specific');
         }
 
@@ -254,5 +260,34 @@ class SendmailTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->transport->send($message);
+    }
+
+    /**
+     * @see @see https://github.com/laminas/laminas-mail/issues/19
+     */
+    public function testHeadersToAndSubjectAreNotDuplicated()
+    {
+        $lineBreak = $this->isWindows() ? "\r\n" : "\n";
+
+        $message = new Message();
+        $message
+            ->addTo('matthew@example.org')
+            ->addFrom('ralph@example.org')
+            ->setSubject('Greetings and Salutations!')
+            ->setBody("Sorry, I'm going to be late today!");
+
+        $this->transport->send($message);
+
+        $this->assertEquals('matthew@example.org', $this->to);
+        $this->assertEquals('Greetings and Salutations!', $this->subject);
+
+        $this->assertNotContains(
+            'To: matthew@example.org, matthew@example.org' . $lineBreak,
+            $this->additional_headers
+        );
+        $this->assertNotContains(
+            'Subject: Greetings and Salutations!, Greetings and Salutations!' . $lineBreak,
+            $this->additional_headers
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Re-create https://github.com/zendframework/zend-mail/pull/225 by @arueckauer Fixes #19 #72 . Original issue description reported by @matbech : 

#### Summary

On Windows with PHP 7, when sending an mail message with the Sendmail transport, the subject header is duplicated.

#### Steps to reproduce

To reproduce the bug the sample from here can be used:
http://framework.zend.com/manual/current/en/modules/zend.mail.introduction.html

The resulting mail headers look something like this:

```text
Subject: Test Subject
Date: Wed, 29 Jul 2015 17:33:17 +0000
From: =?UTF-8?Q?test?= test@test.com
To: test@test.com
Subject: Test Subject
```

#### Cause

In the Sendmail transport all headers (including the Subject) and the subject itself are passed to the php mail function:

```php
$result = mail($to, $subject, $message, $headers);
```

The mail function then appends to the `$subject` to the `$headers`. I do not think the php mail function should handle this case because it doesn't know what subject the caller intended to use. However I believe php mail should at least issue a warning (TBD: file enhancement at https://bugs.php.net/).