### PR TITLE
Address::getName() is nullable, fix annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#107](https://github.com/laminas/laminas-mail/pull/107) corrects a return type annotation in Laminas\Mail\Address\AddressInterface and in implementer.
 
 ## 2.12.1 - 2020-08-05
 

--- a/src/Address.php
+++ b/src/Address.php
@@ -108,9 +108,9 @@ class Address implements Address\AddressInterface
     }
 
     /**
-     * Retrieve name
+     * Retrieve name, if any
      *
-     * @return string
+     * @return null|string
      */
     public function getName()
     {

--- a/src/Address/AddressInterface.php
+++ b/src/Address/AddressInterface.php
@@ -18,9 +18,9 @@ interface AddressInterface
     public function getEmail();
 
     /**
-     * Retrieve name
+     * Retrieve name, if any
      *
-     * @return string
+     * @return null|string
      */
     public function getName();
 


### PR DESCRIPTION
- RFC822 and following allow an address without a name
- fromString() allows this
- it is a common occurence in the wild
- do not change behavior, only correctly document the current behavior

  * Documentation/bugfix: master branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Tell us about why this change is necessary:
getName() annotation was `@return string`, but it can (and does) return null:

```
<?php

class Address 
{
    protected $name;

    public static function fromString($address, $comment = null)
    {
        if (! preg_match('/^((?P<name>.*)<(?P<namedEmail>[^>]+)>|(?P<email>.+))$/', $address, $matches)) {
            throw new \InvalidArgumentException('Invalid address format');
        }

        $name = null;
        if (isset($matches['name'])) {
            $name = trim($matches['name']);
        }
        if (empty($name)) {
            $name = null;
        }

        if (isset($matches['namedEmail'])) {
            $email = $matches['namedEmail'];
        }
        if (isset($matches['email'])) {
            $email = $matches['email'];
        }
        $email = trim($email);

        return new static($email, $name, $comment);
    }

    /**
     * Constructor
     *
     * @param  string $email
     * @param  null|string $name
     * @param  null|string $comment
     * @throws Exception\InvalidArgumentException
     */
    public function __construct($email, $name = null, $comment = null)
    {
        if (preg_match("/[\r\n]/", $email)) {
            throw new \InvalidArgumentException('CRLF injection detected');
        }

        if (null !== $name) {
            if (! is_string($name)) {
                throw new \InvalidArgumentException('Name must be a string');
            }

            if (preg_match("/[\r\n]/", $name)) {
                throw new \InvalidArgumentException('CRLF injection detected');
            }

            $this->name = $name;
        } // else no access happens to $this->name


    }

    /**
     * Retrieve name, if any
     *
     * @return string
     */
    public function getName()
    {
        return $this->name;
    }


}

$address=Address::fromString('example@example.com');

var_dump($address);
var_dump($address->getName());
```

Output:

```
object(Address)#1 (1) {
  ["name":protected]=>
  NULL
}
NULL
```

This path is expected by the code, but not by the annotation.

Note that this can _theoretically_ be a BC for code using this class/interface - a public function's return signature is changed. However, I would assume that most users do encounter email addresses with no name on a regular basis, and thus ignore the previous "non-null" warning as a false positive, and do handle the returned value as nullable (else their code breaks now).

The BC would probably manifest as static analyzers complaining (e.g. PhpStan's "ignored error not matched"); would not break code execution.

This PR makes the annotation consistent with the behavior.