### PR TITLE
Fix Invalid header line for Content-Disposition string - incomplete continuation

### DIFF
--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -68,6 +68,22 @@ class ContentDisposition implements UnstructuredInterface
 
                 if (strpos($name, '*')) {
                     list($name, $count) = explode('*', $name);
+                    // allow optional count:
+                    // Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67
+                    if ($count === "") {
+                        $count = 0;
+                    }
+
+                    if (! is_numeric($count)) {
+                        $type = gettype($count);
+                        $value = var_export($count, 1);
+                        throw new Exception\InvalidArgumentException(sprintf(
+                            "Invalid header line for Content-Disposition string".
+                            " - count expected to be numeric, got %s with value %s",
+                            $type,
+                            $value
+                        ));
+                    }
                     if (! isset($continuedValues[$name])) {
                         $continuedValues[$name] = [];
                     }
@@ -82,7 +98,8 @@ class ContentDisposition implements UnstructuredInterface
                 for ($i = 0; $i < count($values); $i++) {
                     if (! isset($values[$i])) {
                         throw new Exception\InvalidArgumentException(
-                            'Invalid header line for Content-Disposition string - incomplete continuation'
+                            'Invalid header line for Content-Disposition string - incomplete continuation'.
+                            '; HeaderLine: '.$headerLine
                         );
                     }
                     $value .= $values[$i];

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -273,6 +273,7 @@ class ContentDispositionTest extends TestCase
 
     public function parameterWrappingProvider(): iterable
     {
+        // @codingStandardsIgnoreStart
         yield 'Without sequence number' => [
             "Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67",
             'attachment',
@@ -290,6 +291,7 @@ class ContentDispositionTest extends TestCase
             'attachment',
             ['filename' => "utf-8''Capture%20d%E2%80%99e%CC%81cran%202020%2D05%2D13%20a%CC%80%2017.13.47.png"]
         ];
+        // @codingStandardsIgnoreEnd
     }
 
     public function parameterWrappingProviderExceptions(): iterable

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -144,6 +144,16 @@ class ContentDispositionTest extends TestCase
     }
 
     /**
+     * @dataProvider parameterWrappingProviderExceptions
+     */
+    public function testParameterWrappingExceptions(string $input, string $exception, string $message): void
+    {
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
+        ContentDisposition::fromString($input);
+    }
+
+    /**
      * @dataProvider invalidParametersProvider
      */
     public function testSetParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage)
@@ -275,5 +285,18 @@ class ContentDispositionTest extends TestCase
             'attachment',
             ['filename' => "UTF-8''%76%C3%A4%6C%6A%61%70%C3%A4%C3%A4%73%75%2D%65%69%2D%6F%6C%65%2E%6A%70%67"]
         ];
+    }
+
+    public function parameterWrappingProviderExceptions(): iterable
+    {
+        // @codingStandardsIgnoreStart
+        yield 'With non-numeric-sequence' => [
+            "Content-Disposition: attachment;" .
+            "filename*0*=UTF-8''%76%C3%A4%6C%6A%61%70%C3%A4%C3%A4%73%75%2D%65%69%2D%6F;" .
+            "filename*a*=%6C%65%2E%6A%70%67",
+            InvalidArgumentException::class,
+            "Invalid header line for Content-Disposition string - count expected to be numeric, got string with value 'a'"
+        ];
+        // @codingStandardsIgnoreEnd
     }
 }

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -133,19 +133,14 @@ class ContentDispositionTest extends TestCase
      * Should not throw if the optional count is missing
      *
      * @see https://tools.ietf.org/html/rfc2231
+     * @dataProvider parameterWrappingProvider
      */
-    public function testParameterValueOptionalContinuationsRFC2231(): void
+    public function testParameterWrapping(string $input, string $disposition, array $parameters): void
     {
-        $input1 = "Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67";
-        $header = ContentDisposition::fromString($input1);
+        $header = ContentDisposition::fromString($input);
 
-        $this->assertEquals('attachment', $header->getDisposition());
-        $this->assertEquals(['filename' => "UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67"], $header->getParameters());
-
-        $input2 = "Content-Type: application/x-stuff; title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A";
-        $header = ContentType::fromString($input2);
-
-        $this->assertEquals(['title*' => "us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A"], $header->getParameters());
+        $this->assertEquals($disposition, $header->getDisposition());
+        $this->assertEquals($parameters, $header->getParameters());
     }
 
     /**
@@ -264,5 +259,14 @@ class ContentDispositionTest extends TestCase
             ]
         ];
         // @codingStandardsIgnoreEnd
+    }
+
+    public function parameterWrappingProvider(): iterable
+    {
+        yield 'Without sequence number' => [
+            "Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67",
+            'attachment',
+            ['filename' => "UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67"]
+        ];
     }
 }

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -285,6 +285,11 @@ class ContentDispositionTest extends TestCase
             'attachment',
             ['filename' => "UTF-8''%76%C3%A4%6C%6A%61%70%C3%A4%C3%A4%73%75%2D%65%69%2D%6F%6C%65%2E%6A%70%67"]
         ];
+        yield 'With two ordered items' => [
+            "Content-Disposition: attachment; filename*=utf-8''Capture%20d%E2%80%99e%CC%81cran%202020%2D05%2D13%20a%CC%80%2017.13.47.png",
+            'attachment',
+            ['filename' => "utf-8''Capture%20d%E2%80%99e%CC%81cran%202020%2D05%2D13%20a%CC%80%2017.13.47.png"]
+        ];
     }
 
     public function parameterWrappingProviderExceptions(): iterable

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -268,5 +268,12 @@ class ContentDispositionTest extends TestCase
             'attachment',
             ['filename' => "UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67"]
         ];
+        yield 'With two ordered items' => [
+            "Content-Disposition: attachment;" .
+            "filename*0*=UTF-8''%76%C3%A4%6C%6A%61%70%C3%A4%C3%A4%73%75%2D%65%69%2D%6F;" .
+            "filename*1*=%6C%65%2E%6A%70%67",
+            'attachment',
+            ['filename' => "UTF-8''%76%C3%A4%6C%6A%61%70%C3%A4%C3%A4%73%75%2D%65%69%2D%6F%6C%65%2E%6A%70%67"]
+        ];
     }
 }

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -136,11 +136,16 @@ class ContentDispositionTest extends TestCase
      */
     public function testParameterValueOptionalContinuationsRFC2231(): void
     {
-        $input = "Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67";
-        $header = ContentDisposition::fromString($input);
+        $input1 = "Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67";
+        $header = ContentDisposition::fromString($input1);
 
         $this->assertEquals('attachment', $header->getDisposition());
         $this->assertEquals(['filename' => "UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67"], $header->getParameters());
+
+        $input2 = "Content-Type: application/x-stuff; title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A";
+        $header = ContentType::fromString($input2);
+
+        $this->assertEquals(['title*' => "us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A"], $header->getParameters());
     }
 
     /**

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -130,6 +130,20 @@ class ContentDispositionTest extends TestCase
     }
 
     /**
+     * Should not throw if the optional count is missing
+     *
+     * @see https://tools.ietf.org/html/rfc2231
+     */
+    public function testParameterValueOptionalContinuationsRFC2231(): void
+    {
+        $input = "Content-Disposition: attachment; filename*=UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67";
+        $header = ContentDisposition::fromString($input);
+
+        $this->assertEquals('attachment', $header->getDisposition());
+        $this->assertEquals(['filename' => "UTF-8''%64%61%61%6D%69%2D%6D%C3%B5%72%76%2E%6A%70%67"], $header->getParameters());
+    }
+
+    /**
      * @dataProvider invalidParametersProvider
      */
     public function testSetParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage)

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -124,6 +124,19 @@ class ContentTypeTest extends TestCase
     }
 
     /**
+     * Should not throw if the optional count is missing
+     *
+     * @see https://tools.ietf.org/html/rfc2231
+     * @dataProvider parameterWrappingProvider
+     */
+    public function testParameterWrapping(string $input, array $parameters): void
+    {
+        $header = ContentType::fromString($input);
+
+        $this->assertEquals($parameters, $header->getParameters());
+    }
+
+    /**
      * @dataProvider invalidParametersProvider
      */
     public function testAddParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage)
@@ -244,5 +257,13 @@ class ContentTypeTest extends TestCase
     {
         $header = ContentType::fromString('content-type: text/plain');
         $this->assertFalse($header->removeParameter('level'));
+    }
+
+    public function parameterWrappingProvider(): iterable
+    {
+        yield 'Example from RFC2231' => [
+            "Content-Type: application/x-stuff; title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A",
+            ['title*' => "us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A"]
+        ];
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| Critical      | yes

### Description

https://tools.ietf.org/html/rfc2231 allows the sequence (internally $count) being missing:

```
        Content-Type: application/x-stuff;
         title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A
```

However `ContentDisposition` expected it to be number, and failed to cast empty string to numeric index. This resulted in throwing `InvalidArgumentException(code: 0): Invalid header line for Content-Disposition string - incomplete continuation`

Additionally, seems similar logic is needed ion ContentType class, but it's partly duplicated, ContentDisposition has more logic, and the exception is presented only in ContentDisposition class.
