### PR TITLE
Code style fixes in tests

### DIFF
--- a/src/AddressList.php
+++ b/src/AddressList.php
@@ -105,7 +105,7 @@ class AddressList implements Countable, Iterator
      * @param  AddressList $addressList
      * @return AddressList
      */
-    public function merge(AddressList $addressList)
+    public function merge(self $addressList)
     {
         foreach ($addressList as $address) {
             $this->add($address);

--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -79,7 +79,7 @@ class ContentDisposition implements UnstructuredInterface
 
             foreach ($continuedValues as $name => $values) {
                 $value = '';
-                for ($i = 0; $i < count($values); $i++) {
+                for ($i = 0, $iMax = count($values); $i < $iMax; $i++) {
                     if (! isset($values[$i])) {
                         throw new Exception\InvalidArgumentException(
                             'Invalid header line for Content-Disposition string - incomplete continuation'

--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -18,7 +18,7 @@ class ContentDisposition implements UnstructuredInterface
      *
      * @var int
      */
-    const MAX_PARAMETER_LENGTH = 76;
+    public const MAX_PARAMETER_LENGTH = 76;
 
     /**
      * @var string

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -181,7 +181,8 @@ class ContentType implements UnstructuredInterface
         if (isset($this->parameters[$name])) {
             return $this->parameters[$name];
         }
-        return;
+
+        return null;
     }
 
     /**

--- a/src/Header/HeaderInterface.php
+++ b/src/Header/HeaderInterface.php
@@ -47,7 +47,7 @@ interface HeaderInterface
      * @param  bool $format Return the value in Mime::Encoded or in Raw format
      * @return string
      */
-    public function getFieldValue($format = HeaderInterface::FORMAT_RAW);
+    public function getFieldValue($format = self::FORMAT_RAW);
 
     /**
      * Set header encoding

--- a/src/Header/HeaderInterface.php
+++ b/src/Header/HeaderInterface.php
@@ -15,14 +15,14 @@ interface HeaderInterface
      *
      * @var bool
      */
-    const FORMAT_ENCODED = true;
+    public const FORMAT_ENCODED = true;
 
     /**
      * Return value in internal encoding which is usually UTF-8
      *
      * @var bool
      */
-    const FORMAT_RAW     = false;
+    public const FORMAT_RAW     = false;
 
     /**
      * Factory to generate a header object from a string

--- a/src/Header/HeaderLocator.php
+++ b/src/Header/HeaderLocator.php
@@ -50,7 +50,7 @@ final class HeaderLocator implements HeaderLocatorInterface
     public function get(string $name, ?string $default = null): ?string
     {
         $name = $this->normalizeName($name);
-        return isset($this->plugins[$name]) ? $this->plugins[$name] : $default;
+        return $this->plugins[$name] ?? $default;
     }
 
     public function has(string $name): bool

--- a/src/Header/IdentificationField.php
+++ b/src/Header/IdentificationField.php
@@ -47,7 +47,7 @@ abstract class IdentificationField implements HeaderInterface
         $value = HeaderWrap::mimeDecodeValue($value);
 
         $messageIds = array_map(
-            [IdentificationField::class, "trimMessageId"],
+            [self::class, "trimMessageId"],
             explode(" ", $value)
         );
 
@@ -127,7 +127,7 @@ abstract class IdentificationField implements HeaderInterface
             }
         }
 
-        $this->messageIds = array_map([IdentificationField::class, "trimMessageId"], $ids);
+        $this->messageIds = array_map([self::class, "trimMessageId"], $ids);
         return $this;
     }
 

--- a/src/Header/ListParser.php
+++ b/src/Header/ListParser.php
@@ -15,9 +15,9 @@ use function in_array;
  */
 class ListParser
 {
-    const CHAR_QUOTES = ['\'', '"'];
-    const CHAR_DELIMS = [',', ';'];
-    const CHAR_ESCAPE = '\\';
+    public const CHAR_QUOTES = ['\'', '"'];
+    public const CHAR_DELIMS = [',', ';'];
+    public const CHAR_ESCAPE = '\\';
 
     /**
      * @param string $value

--- a/src/Header/Received.php
+++ b/src/Header/Received.php
@@ -80,7 +80,7 @@ class Received implements HeaderInterface, MultipleHeadersInterface
     {
         $strings = [$this->toString()];
         foreach ($headers as $header) {
-            if (! $header instanceof Received) {
+            if (! $header instanceof self) {
                 throw new Exception\RuntimeException(
                     'The Received multiple header implementation can only accept an array of Received headers'
                 );

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -391,10 +391,8 @@ class Headers implements Countable, Iterator
             case 1:
                 if ($results[0] instanceof Header\MultipleHeadersInterface) {
                     return new ArrayIterator($results);
-                } else {
-                    return $results[0];
                 }
-                //fall-trough
+                return $results[0];
             default:
                 return new ArrayIterator($results);
         }

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -538,7 +538,7 @@ class Headers implements Countable, Iterator
      */
     public function loadHeader($headerLine)
     {
-        list($name, ) = Header\GenericHeader::splitHeaderLine($headerLine);
+        list($name) = Header\GenericHeader::splitHeaderLine($headerLine);
 
         /** @var HeaderInterface $class */
         $class = $this->resolveHeaderClass($name);

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -13,7 +13,6 @@ namespace Laminas\Mail;
 use ArrayIterator;
 use Countable;
 use Iterator;
-use Laminas\Loader\PluginClassLoader;
 use Laminas\Loader\PluginClassLocator;
 use Laminas\Mail\Header\GenericHeader;
 use Laminas\Mail\Header\HeaderInterface;

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -26,10 +26,10 @@ use Traversable;
 class Headers implements Countable, Iterator
 {
     /** @var string End of Line for fields */
-    const EOL = "\r\n";
+    public const EOL = "\r\n";
 
     /** @var string Start of Line when folding */
-    const FOLDING = "\r\n ";
+    public const FOLDING = "\r\n ";
 
     /**
      * @var null|Header\HeaderLocatorInterface

--- a/src/Protocol/AbstractProtocol.php
+++ b/src/Protocol/AbstractProtocol.php
@@ -21,12 +21,12 @@ abstract class AbstractProtocol
     /**
      * Mail default EOL string
      */
-    const EOL = "\r\n";
+    public const EOL = "\r\n";
 
     /**
      * Default timeout in seconds for initiating session
      */
-    const TIMEOUT_CONNECTION = 30;
+    public const TIMEOUT_CONNECTION = 30;
 
     /**
      * Maximum of the transaction log

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -15,7 +15,7 @@ class Imap
     /**
      * Default timeout in seconds for initiating session
      */
-    const TIMEOUT_CONNECTION = 30;
+    public const TIMEOUT_CONNECTION = 30;
 
     /**
      * @var null|resource

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -364,10 +364,11 @@ class Imap
         if (func_num_args() < 2) {
             if (strpos($string, "\n") !== false) {
                 return ['{' . strlen($string) . '}', $string];
-            } else {
-                return '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $string) . '"';
             }
+
+            return '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $string) . '"';
         }
+
         $result = [];
         foreach (func_get_args() as $string) {
             $result[] = $this->escapeString($string);

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -290,13 +290,13 @@ class Imap
             // last to chars are still needed for response code
             $tokens = [substr($tokens, 0, 2)];
         }
+
         // last line has response code
         if ($tokens[0] == 'OK') {
             return $lines ? $lines : true;
         } elseif ($tokens[0] == 'NO') {
             return false;
         }
-        return;
     }
 
     /**

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -127,7 +127,7 @@ class Pop3
     public function sendRequest($request)
     {
         ErrorHandler::start();
-        $result = fputs($this->socket, $request . "\r\n");
+        $result = fwrite($this->socket, $request . "\r\n");
         $error  = ErrorHandler::stop();
         if (! $result) {
             throw new Exception\RuntimeException('send failed - connection closed?', 0, $error);

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -339,9 +339,9 @@ class Pop3
         if ($this->hasTop === false) {
             if ($fallback) {
                 return $this->retrieve($msgno);
-            } else {
-                throw new Exception\RuntimeException('top not supported and no fallback wanted');
             }
+
+            throw new Exception\RuntimeException('top not supported and no fallback wanted');
         }
         $this->hasTop = true;
 

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -17,7 +17,7 @@ class Pop3
     /**
      * Default timeout in seconds for initiating session
      */
-    const TIMEOUT_CONNECTION = 30;
+    public const TIMEOUT_CONNECTION = 30;
 
     /**
      * saves if server supports top

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -171,7 +171,7 @@ class Pop3
                 }
                 $message .= $line;
                 $line = fgets($this->socket);
-            };
+            }
         }
 
         return $message;

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -209,7 +209,6 @@ class Pop3
         }
     }
 
-
     /**
      * Get capabilities from POP3 server
      *
@@ -220,7 +219,6 @@ class Pop3
         $result = $this->request('CAPA', true);
         return explode("\n", $result);
     }
-
 
     /**
      * Login to POP3 server. Can use APOP
@@ -244,7 +242,6 @@ class Pop3
         $this->request("PASS $password");
     }
 
-
     /**
      * Make STAT call for message count and size sum
      *
@@ -259,7 +256,6 @@ class Pop3
 
         list($messages, $octets) = explode(' ', $result);
     }
-
 
     /**
      * Make LIST call for size of message(s)
@@ -287,7 +283,6 @@ class Pop3
 
         return $messages;
     }
-
 
     /**
      * Make UIDL call for getting a uniqueid
@@ -318,7 +313,6 @@ class Pop3
 
         return $messages;
     }
-
 
     /**
      * Make TOP call for getting headers and maybe some body lines

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -21,7 +21,6 @@ trait ProtocolTrait
      */
     protected $novalidatecert;
 
-
     public function getCryptoMethod(): int
     {
         // Allow the best TLS version(s) we can

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -71,7 +71,7 @@ trait ProtocolTrait
                 'ssl' => [
                     'verify_peer_name' => false,
                     'verify_peer'      => false,
-                ]
+                ],
             ]
             : [];
     }

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -260,7 +260,6 @@ class Smtp extends AbstractProtocol
         }
     }
 
-
     /**
      * Issues MAIL command
      *
@@ -282,7 +281,6 @@ class Smtp extends AbstractProtocol
         $this->data = false;
     }
 
-
     /**
      * Issues RCPT command
      *
@@ -300,7 +298,6 @@ class Smtp extends AbstractProtocol
         $this->_expect([250, 251], 300); // Timeout set for 5 minutes as per RFC 2821 4.5.3.2
         $this->rcpt = true;
     }
-
 
     /**
      * Issues DATA command
@@ -342,7 +339,6 @@ class Smtp extends AbstractProtocol
         $this->_expect(250, 600); // Timeout set for 10 minutes as per RFC 2821 4.5.3.2
         $this->data = true;
     }
-
 
     /**
      * Issues the RSET command end validates answer

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -12,12 +12,12 @@ class Storage
 {
     // maildir and IMAP flags, using IMAP names, where possible to be able to distinguish between IMAP
     // system flags and other flags
-    const FLAG_PASSED   = 'Passed';
-    const FLAG_SEEN     = '\Seen';
-    const FLAG_UNSEEN   = '\Unseen';
-    const FLAG_ANSWERED = '\Answered';
-    const FLAG_FLAGGED  = '\Flagged';
-    const FLAG_DELETED  = '\Deleted';
-    const FLAG_DRAFT    = '\Draft';
-    const FLAG_RECENT   = '\Recent';
+    public const FLAG_PASSED   = 'Passed';
+    public const FLAG_SEEN     = '\Seen';
+    public const FLAG_UNSEEN   = '\Unseen';
+    public const FLAG_ANSWERED = '\Answered';
+    public const FLAG_FLAGGED  = '\Flagged';
+    public const FLAG_DELETED  = '\Deleted';
+    public const FLAG_DRAFT    = '\Draft';
+    public const FLAG_RECENT   = '\Recent';
 }

--- a/src/Storage/Folder.php
+++ b/src/Storage/Folder.php
@@ -61,7 +61,7 @@ class Folder implements RecursiveIterator
     public function hasChildren()
     {
         $current = $this->current();
-        return $current && $current instanceof Folder && ! $current->isLeaf();
+        return $current && $current instanceof self && ! $current->isLeaf();
     }
 
     /**
@@ -142,7 +142,7 @@ class Folder implements RecursiveIterator
      * @param string $name local name of subfolder
      * @param \Laminas\Mail\Storage\Folder $folder instance for new subfolder
      */
-    public function __set($name, Folder $folder)
+    public function __set($name, self $folder)
     {
         $this->folders[$name] = $folder;
     }

--- a/src/Storage/Folder/Mbox.php
+++ b/src/Storage/Folder/Mbox.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Mail\Storage\Folder;
 
+use Laminas\Config\Config;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
 use Laminas\Stdlib\ErrorHandler;
@@ -43,7 +44,7 @@ class Mbox extends Storage\Mbox implements FolderInterface
      * - dirname rootdir of mbox structure
      * - folder initial selected folder, default is 'INBOX'
      *
-     * @param  $params array mail reader specific parameters
+     * @param  $params array|object|Config mail reader specific parameters
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($params)

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -121,7 +121,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
 
         $flags = [];
         foreach ($data['FLAGS'] as $flag) {
-            $flags[] = isset(static::$knownFlags[$flag]) ? static::$knownFlags[$flag] : $flag;
+            $flags[] = static::$knownFlags[$flag] ?? $flag;
         }
 
         return new $this->messageClass(['handler' => $this, 'id' => $id, 'headers' => $header, 'flags' => $flags]);

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -8,7 +8,6 @@
 
 namespace Laminas\Mail\Storage;
 
-use Laminas\Config\Config;
 use Laminas\Mail;
 use Laminas\Mail\Protocol;
 
@@ -181,7 +180,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
      * - ssl 'SSL' or 'TLS' for secure sockets
      * - folder select this folder [optional, default = 'INBOX']
      *
-     * @param  array|object|Config|Protocol\Imap $params mail reader specific parameters or configured Imap protocol object
+     * @param  array|Protocol\Imap $params mail reader specific parameters or configured Imap protocol object
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      * @throws Protocol\Exception\RuntimeException

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Mail\Storage;
 
+use Laminas\Config\Config;
 use Laminas\Mail;
 use Laminas\Mail\Protocol;
 
@@ -180,7 +181,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
      * - ssl 'SSL' or 'TLS' for secure sockets
      * - folder select this folder [optional, default = 'INBOX']
      *
-     * @param  array|Protocol\Imap $params mail reader specific parameters or configured Imap protocol object
+     * @param  array|object|Config|Protocol\Imap $params mail reader specific parameters or configured Imap protocol object
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      * @throws Protocol\Exception\RuntimeException

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -329,7 +329,7 @@ class Maildir extends AbstractStorage
                 'uniq'       => $uniq,
                 'flags'      => $namedFlags,
                 'flaglookup' => array_flip($namedFlags),
-                'filename'   => $dirname . $entry
+                'filename'   => $dirname . $entry,
             ];
             if ($size !== null) {
                 $data['size'] = (int) $size;

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -112,12 +112,12 @@ class Maildir extends AbstractStorage
     {
         if ($id !== null) {
             $filedata = $this->getFileData($id);
-            return isset($filedata['size']) ? $filedata['size'] : filesize($filedata['filename']);
+            return $filedata['size'] ?? filesize($filedata['filename']);
         }
 
         $result = [];
         foreach ($this->files as $num => $data) {
-            $result[$num + 1] = isset($data['size']) ? $data['size'] : filesize($data['filename']);
+            $result[$num + 1] = $data['size'] ?? filesize($data['filename']);
         }
 
         return $result;
@@ -322,7 +322,7 @@ class Maildir extends AbstractStorage
             $length = strlen($flags);
             for ($i = 0; $i < $length; ++$i) {
                 $flag = $flags[$i];
-                $namedFlags[$flag] = isset(static::$knownFlags[$flag]) ? static::$knownFlags[$flag] : $flag;
+                $namedFlags[$flag] = static::$knownFlags[$flag] ?? $flag;
             }
 
             $data = [

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Mail\Storage;
 
+use Laminas\Config\Config;
 use Laminas\Mail;
 use Laminas\Stdlib\ErrorHandler;
 
@@ -215,7 +216,7 @@ class Maildir extends AbstractStorage
      * Supported parameters are:
      *   - dirname dirname of mbox file
      *
-     * @param  $params array mail reader specific parameters
+     * @param  $params array|object|Config mail reader specific parameters
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($params)

--- a/src/Storage/Mbox.php
+++ b/src/Storage/Mbox.php
@@ -115,7 +115,7 @@ class Mbox extends AbstractStorage
             $messageClassParams = [
                 'file' => $this->fh,
                 'startPos' => $messagePos['start'],
-                'endPos' => $messagePos['end']
+                'endPos' => $messagePos['end'],
             ];
 
             if (isset($this->messageEOL)) {

--- a/src/Storage/Mbox.php
+++ b/src/Storage/Mbox.php
@@ -312,7 +312,6 @@ class Mbox extends AbstractStorage
         $this->positions = [];
     }
 
-
     /**
      * Waste some CPU cycles doing nothing.
      *
@@ -322,7 +321,6 @@ class Mbox extends AbstractStorage
     {
         return true;
     }
-
 
     /**
      * stub for not supported message deletion

--- a/src/Storage/Mbox.php
+++ b/src/Storage/Mbox.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Mail\Storage;
 
+use Laminas\Config\Config;
 use Laminas\Stdlib\ErrorHandler;
 
 class Mbox extends AbstractStorage
@@ -184,7 +185,7 @@ class Mbox extends AbstractStorage
      * Supported parameters are:
      *   - filename filename of mbox file
      *
-     * @param  $params array mail reader specific parameters
+     * @param  $params array|object|Config mail reader specific parameters
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($params)

--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -407,7 +407,7 @@ class Part implements RecursiveIterator, Part\PartInterface
     public function hasChildren()
     {
         $current = $this->current();
-        return $current && $current instanceof Part && $current->isMultipart();
+        return $current && $current instanceof self && $current->isMultipart();
     }
 
     /**

--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -92,7 +92,7 @@ class Part implements RecursiveIterator, Part\PartInterface
             $this->messageNum = $params['id'];
         }
 
-        $params['strict'] = isset($params['strict']) ? $params['strict'] : false;
+        $params['strict'] = $params['strict'] ?? false;
 
         if (isset($params['raw'])) {
             Mime\Decode::splitMessage(

--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -134,7 +134,6 @@ class Part implements RecursiveIterator, Part\PartInterface
         }
     }
 
-
     /**
      * Body of part
      *
@@ -167,7 +166,6 @@ class Part implements RecursiveIterator, Part\PartInterface
     {
         return strlen($this->getContent());
     }
-
 
     /**
      * Cache content and split in parts if multipart

--- a/src/Storage/Part/File.php
+++ b/src/Storage/Part/File.php
@@ -48,7 +48,7 @@ class File extends Part
             fseek($this->fh, $params['startPos']);
         }
         $header = '';
-        $endPos = isset($params['endPos']) ? $params['endPos'] : null;
+        $endPos = $params['endPos'] ?? null;
         while (($endPos === null || ftell($this->fh) < $endPos) && trim($line = fgets($this->fh))) {
             $header .= $line;
         }

--- a/src/Storage/Part/File.php
+++ b/src/Storage/Part/File.php
@@ -151,7 +151,10 @@ class File extends Part
             throw new Exception\RuntimeException('part not found');
         }
 
-        return new static(['file' => $this->fh, 'startPos' => $this->partPos[$num][0],
-                              'endPos' => $this->partPos[$num][1]]);
+        return new static([
+            'file' => $this->fh,
+            'startPos' => $this->partPos[$num][0],
+            'endPos' => $this->partPos[$num][1],
+        ]);
     }
 }

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -60,8 +60,12 @@ class Pop3 extends AbstractStorage
         $bodyLines = 0;
         $message = $this->protocol->top($id, $bodyLines, true);
 
-        return new $this->messageClass(['handler' => $this, 'id' => $id, 'headers' => $message,
-                                              'noToplines' => $bodyLines < 1]);
+        return new $this->messageClass([
+            'handler' => $this,
+            'id' => $id,
+            'headers' => $message,
+            'noToplines' => $bodyLines < 1,
+        ]);
     }
 
     /*

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Mail\Storage;
 
+use Laminas\Config\Config;
 use Laminas\Mail\Exception as MailException;
 use Laminas\Mail\Protocol;
 use Laminas\Mime;
@@ -121,7 +122,7 @@ class Pop3 extends AbstractStorage
      *   - port port for POP3 server [optional, default = 110]
      *   - ssl 'SSL' or 'TLS' for secure sockets
      *
-     * @param  array|Protocol\Pop3 $params mail reader specific parameters or configured Pop3 protocol object
+     * @param  array|object|Config|Protocol\Pop3 $params mail reader specific parameters or configured Pop3 protocol object
      * @throws \Laminas\Mail\Storage\Exception\InvalidArgumentException
      * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
      */

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -8,7 +8,6 @@
 
 namespace Laminas\Mail\Storage;
 
-use Laminas\Config\Config;
 use Laminas\Mail\Exception as MailException;
 use Laminas\Mail\Protocol;
 use Laminas\Mime;
@@ -122,7 +121,7 @@ class Pop3 extends AbstractStorage
      *   - port port for POP3 server [optional, default = 110]
      *   - ssl 'SSL' or 'TLS' for secure sockets
      *
-     * @param  array|object|Config|Protocol\Pop3 $params mail reader specific parameters or configured Pop3 protocol object
+     * @param  array|Protocol\Pop3 $params mail reader specific parameters or configured Pop3 protocol object
      * @throws \Laminas\Mail\Storage\Exception\InvalidArgumentException
      * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
      */

--- a/src/Storage/Writable/Maildir.php
+++ b/src/Storage/Writable/Maildir.php
@@ -390,10 +390,12 @@ class Maildir extends Folder\Maildir implements WritableInterface
             );
         }
 
-        return ['dirname'  => $this->rootdir . '.' . $folder,
-                     'uniq'     => $uniq,
-                     'filename' => $tmpdir . $uniq,
-                     'handle'   => $fh];
+        return [
+            'dirname' => $this->rootdir . '.' . $folder,
+            'uniq' => $uniq,
+            'filename' => $tmpdir . $uniq,
+            'handle' => $fh,
+        ];
     }
 
     /**
@@ -495,9 +497,11 @@ class Maildir extends Folder\Maildir implements WritableInterface
             throw $exception;
         }
 
-        $this->files[] = ['uniq'     => $tempFile['uniq'],
-                                'flags'    => $flags,
-                                'filename' => $newFilename];
+        $this->files[] = [
+            'uniq' => $tempFile['uniq'],
+            'flags' => $flags,
+            'filename' => $newFilename,
+        ];
         if ($this->quota) {
             $this->addQuotaEntry((int) $size, 1);
         }
@@ -563,9 +567,11 @@ class Maildir extends Folder\Maildir implements WritableInterface
         if ($folder->getGlobalName() == $this->currentFolder
             || ($this->currentFolder == 'INBOX' && $folder->getGlobalName() == '/')
         ) {
-            $this->files[] = ['uniq'     => $tempFile['uniq'],
-                                    'flags'    => $flags,
-                                    'filename' => $newFile];
+            $this->files[] = [
+                'uniq' => $tempFile['uniq'],
+                'flags' => $flags,
+                'filename' => $newFile,
+            ];
         }
 
         if ($this->quota) {
@@ -841,9 +847,11 @@ class Maildir extends Folder\Maildir implements WritableInterface
             }
         }
 
-        return ['size'  => $totalSize,
-                     'count' => $messages,
-                     'quota' => $quota];
+        return [
+            'size' => $totalSize,
+            'count' => $messages,
+            'quota' => $quota,
+        ];
     }
 
     /**
@@ -921,10 +929,12 @@ class Maildir extends Folder\Maildir implements WritableInterface
             fclose($fh);
         }
 
-        return ['size'       => $totalSize,
-                     'count'      => $messages,
-                     'quota'      => $quota,
-                     'over_quota' => $overQuota];
+        return [
+            'size' => $totalSize,
+            'count' => $messages,
+            'quota' => $quota,
+            'over_quota' => $overQuota,
+        ];
     }
 
     protected function addQuotaEntry($size, $count = 1)

--- a/src/Storage/Writable/Maildir.php
+++ b/src/Storage/Writable/Maildir.php
@@ -656,7 +656,7 @@ class Maildir extends Folder\Maildir implements WritableInterface
 
         // NOTE: double dirname to make sure we always move to cur. if recent
         // flag has been set (message is in new) it will be moved to cur.
-        $newFilename = dirname(dirname($filedata['filename']))
+        $newFilename = dirname($filedata['filename'], 2)
             . DIRECTORY_SEPARATOR
             . 'cur'
             . DIRECTORY_SEPARATOR

--- a/src/Storage/Writable/Maildir.php
+++ b/src/Storage/Writable/Maildir.php
@@ -51,9 +51,9 @@ class Maildir extends Folder\Maildir implements WritableInterface
                     throw new StorageException\InvalidArgumentException("parent $dir not found", 0, $error);
                 } elseif (! is_dir($dir)) {
                     throw new StorageException\InvalidArgumentException("parent $dir not a directory", 0, $error);
-                } else {
-                    throw new StorageException\RuntimeException('cannot create maildir', 0, $error);
                 }
+
+                throw new StorageException\RuntimeException('cannot create maildir', 0, $error);
             }
         }
 

--- a/src/Transport/Factory.php
+++ b/src/Transport/Factory.php
@@ -61,7 +61,7 @@ abstract class Factory
             ));
         }
 
-        $transport = new $type;
+        $transport = new $type();
 
         if (! $transport instanceof TransportInterface) {
             throw new Exception\DomainException(sprintf(

--- a/src/Transport/Factory.php
+++ b/src/Transport/Factory.php
@@ -45,7 +45,7 @@ abstract class Factory
             ));
         }
 
-        $type = isset($spec['type']) ? $spec['type'] : 'sendmail';
+        $type = $spec['type'] ?? 'sendmail';
 
         $normalizedType = strtolower($type);
 

--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -24,69 +24,69 @@ class AddressListTest extends TestCase
     /** @var AddressList */
     private $list;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->list = new AddressList();
     }
 
-    public function testImplementsCountable()
+    public function testImplementsCountable(): void
     {
         $this->assertInstanceOf(\Countable::class, $this->list);
     }
 
-    public function testIsEmptyByDefault()
+    public function testIsEmptyByDefault(): void
     {
         $this->assertEquals(0, count($this->list));
     }
 
-    public function testAddingEmailsIncreasesCount()
+    public function testAddingEmailsIncreasesCount(): void
     {
         $this->list->add('test@example.com');
         $this->assertEquals(1, count($this->list));
     }
 
-    public function testAddingEmailFromStringIncreasesCount()
+    public function testAddingEmailFromStringIncreasesCount(): void
     {
         $this->list->addFromString('test@example.com');
         $this->assertEquals(1, count($this->list));
     }
 
-    public function testImplementsTraversable()
+    public function testImplementsTraversable(): void
     {
         $this->assertInstanceOf(\Traversable::class, $this->list);
     }
 
-    public function testHasReturnsFalseWhenAddressNotInList()
+    public function testHasReturnsFalseWhenAddressNotInList(): void
     {
         $this->assertFalse($this->list->has('foo@example.com'));
     }
 
-    public function testHasReturnsTrueWhenAddressInList()
+    public function testHasReturnsTrueWhenAddressInList(): void
     {
         $this->list->add('test@example.com');
         $this->assertTrue($this->list->has('test@example.com'));
     }
 
-    public function testGetReturnsFalseWhenEmailNotFound()
+    public function testGetReturnsFalseWhenEmailNotFound(): void
     {
         $this->assertFalse($this->list->get('foo@example.com'));
     }
 
-    public function testThrowExceptionOnInvalidInputAdd()
+    public function testThrowExceptionOnInvalidInputAdd(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('add expects an email address or Laminas\Mail\Address object');
         $this->list->add(null);
     }
 
-    public function testThrowExceptionOnInvalidInputAddMany()
+    public function testThrowExceptionOnInvalidInputAddMany(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('add expects an email address or Laminas\Mail\Address object');
         $this->list->addMany([null]);
     }
 
-    public function testGetReturnsAddressObjectWhenEmailFound()
+    public function testGetReturnsAddressObjectWhenEmailFound(): void
     {
         $this->list->add('test@example.com');
         $address = $this->list->get('test@example.com');
@@ -94,7 +94,7 @@ class AddressListTest extends TestCase
         $this->assertEquals('test@example.com', $address->getEmail());
     }
 
-    public function testCanAddAddressWithName()
+    public function testCanAddAddressWithName(): void
     {
         $this->list->add('test@example.com', 'Example Test');
         $address = $this->list->get('test@example.com');
@@ -103,7 +103,7 @@ class AddressListTest extends TestCase
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testCanAddManyAddressesAtOnce()
+    public function testCanAddManyAddressesAtOnce(): void
     {
         $addresses = [
             'test@example.com',
@@ -117,7 +117,7 @@ class AddressListTest extends TestCase
         $this->assertTrue($this->list->has('announce@example.com'));
     }
 
-    public function testCanAddFromStringFluently()
+    public function testCanAddFromStringFluently(): void
     {
         $this->list->addFromString('test_fromstring_fluency1@example.com')
             ->addFromString('test_fromstring_fluency2@example.com');
@@ -126,7 +126,7 @@ class AddressListTest extends TestCase
         $this->assertTrue($this->list->has('test_fromstring_fluency2@example.com'));
     }
 
-    public function testLosesParensInName()
+    public function testLosesParensInName(): void
     {
         $header = '"Supports (E-mail)" <support@example.org>';
 
@@ -138,7 +138,7 @@ class AddressListTest extends TestCase
         $this->assertEquals('support@example.org', $address->getEmail());
     }
 
-    public function testDoesNotStoreDuplicatesAndFirstWins()
+    public function testDoesNotStoreDuplicatesAndFirstWins(): void
     {
         $addresses = [
             'test@example.com',
@@ -156,7 +156,7 @@ class AddressListTest extends TestCase
      *
      * @see https://blogs.msdn.microsoft.com/oldnewthing/20150119-00/?p=44883
      */
-    public function testSemicolonSeparator()
+    public function testSemicolonSeparator(): void
     {
         $header = 'Some User <some.user@example.com>; uzer2.surname@example.org;'
             . ' asda.fasd@example.net, root@example.org';
@@ -176,7 +176,7 @@ class AddressListTest extends TestCase
         $this->assertTrue($addressList->has('root@example.org'));
     }
 
-    public function testMergeTwoLists()
+    public function testMergeTwoLists(): void
     {
         $otherList = new AddressList();
         $this->list->add('one@example.net');
@@ -185,19 +185,19 @@ class AddressListTest extends TestCase
         $this->assertEquals(2, count($this->list));
     }
 
-    public function testDeleteSuccess()
+    public function testDeleteSuccess(): void
     {
         $this->list->add('test@example.com');
         $this->assertTrue($this->list->delete('test@example.com'));
         $this->assertEquals(0, count($this->list));
     }
 
-    public function testDeleteNotExist()
+    public function testDeleteNotExist(): void
     {
         $this->assertFalse($this->list->delete('test@example.com'));
     }
 
-    public function testKey()
+    public function testKey(): void
     {
         $this->assertNull($this->list->key());
         $this->list->add('test@example.com');
@@ -214,7 +214,7 @@ class AddressListTest extends TestCase
     /**
      * If name-field is quoted with "", then ' inside it should not treated as terminator, but as value.
      */
-    public function testMixedQuotesInName()
+    public function testMixedQuotesInName(): void
     {
         $header = '"Bob O\'Reilly" <bob@example.com>,blah@example.com';
 

--- a/test/AddressTest.php
+++ b/test/AddressTest.php
@@ -17,21 +17,21 @@ use PHPUnit\Framework\TestCase;
  */
 class AddressTest extends TestCase
 {
-    public function testDoesNotRequireNameForInstantiation()
+    public function testDoesNotRequireNameForInstantiation(): void
     {
         $address = new Address('test@example.com');
         $this->assertEquals('test@example.com', $address->getEmail());
         $this->assertNull($address->getName());
     }
 
-    public function testAcceptsNameViaConstructor()
+    public function testAcceptsNameViaConstructor(): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $this->assertEquals('test@example.com', $address->getEmail());
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testToStringCreatesStringRepresentation()
+    public function testToStringCreatesStringRepresentation(): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $this->assertEquals('Example Test <test@example.com>', $address->toString());
@@ -43,13 +43,13 @@ class AddressTest extends TestCase
      * @param string $email
      * @param null|string $name
      */
-    public function testSetAddressInvalidAddressObject($email, $name)
+    public function testSetAddressInvalidAddressObject($email, $name): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Address($email, $name);
     }
 
-    public function invalidSenderDataProvider()
+    public function invalidSenderDataProvider(): array
     {
         return [
             // Description => [sender address, sender name],
@@ -74,13 +74,13 @@ class AddressTest extends TestCase
      * @param string $email
      * @param null|string $name
      */
-    public function testSetAddressValidAddressObject($email, $name)
+    public function testSetAddressValidAddressObject($email, $name): void
     {
         $address = new Address($email, $name);
         $this->assertInstanceOf(Address::class, $address);
     }
 
-    public function validSenderDataProvider()
+    public function validSenderDataProvider(): array
     {
         return [
             // Description => [sender address, sender name],

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigProviderTest extends TestCase
 {
-    public function testInvoke()
+    public function testInvoke(): void
     {
         $configProvider = new ConfigProvider();
         $config = $configProvider();

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -220,13 +220,13 @@ class AddressListHeaderTest extends TestCase
             [
                 "To: =?UTF-8?B?dGVzdCxsYWJlbA==?= <john@example.com>, john2@example.com",
                 ['john@example.com' => 'test,label', 'john2@example.com' => null],
-                'UTF-8'
+                'UTF-8',
             ],
             [
                 'To: "TEST\",QUOTE" <john@example.com>, john2@example.com',
                 ['john@example.com' => 'TEST",QUOTE', 'john2@example.com' => null],
-                'ASCII'
-            ]
+                'ASCII',
+            ],
         ];
     }
 

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AddressListHeaderTest extends TestCase
 {
-    public static function getHeaderInstances()
+    public static function getHeaderInstances(): array
     {
         return [
             [new Bcc(), 'Bcc'],
@@ -37,7 +37,7 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getHeaderInstances
      */
-    public function testConcreteHeadersExtendAbstractAddressListHeader($header)
+    public function testConcreteHeadersExtendAbstractAddressListHeader($header): void
     {
         $this->assertInstanceOf(AbstractAddressList::class, $header);
     }
@@ -45,7 +45,7 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getHeaderInstances
      */
-    public function testConcreteHeaderFieldNamesAreDiscrete($header, $type)
+    public function testConcreteHeaderFieldNamesAreDiscrete($header, $type): void
     {
         $this->assertEquals($type, $header->getFieldName());
     }
@@ -53,19 +53,19 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getHeaderInstances
      */
-    public function testConcreteHeadersComposeAddressLists($header)
+    public function testConcreteHeadersComposeAddressLists($header): void
     {
         $list = $header->getAddressList();
         $this->assertInstanceOf(AddressList::class, $list);
     }
 
-    public function testFieldValueIsEmptyByDefault()
+    public function testFieldValueIsEmptyByDefault(): void
     {
         $header = new To();
         $this->assertEquals('', $header->getFieldValue());
     }
 
-    public function testFieldValueIsCreatedFromAddressList()
+    public function testFieldValueIsCreatedFromAddressList(): void
     {
         $header = new To();
         $list   = $header->getAddressList();
@@ -74,7 +74,7 @@ class AddressListHeaderTest extends TestCase
         $this->assertEquals($expected, $header->getFieldValue());
     }
 
-    public function populateAddressList(AddressList $list)
+    public function populateAddressList(AddressList $list): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $list->add($address);
@@ -83,7 +83,7 @@ class AddressListHeaderTest extends TestCase
         $list->add('first@last.example.com', 'Last, First');
     }
 
-    public function getExpectedFieldValue()
+    public function getExpectedFieldValue(): string
     {
         // @codingStandardsIgnoreStart
         return "Example Test <test@example.com>,\r\n list@example.com,\r\n Example Announce List <announce@example.com>,\r\n \"Last, First\" <first@last.example.com>";
@@ -93,14 +93,14 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getHeaderInstances
      */
-    public function testStringRepresentationIncludesHeaderAndFieldValue($header, $type)
+    public function testStringRepresentationIncludesHeaderAndFieldValue($header, $type): void
     {
         $this->populateAddressList($header->getAddressList());
         $expected = sprintf('%s: %s', $type, $this->getExpectedFieldValue());
         $this->assertEquals($expected, $header->toString());
     }
 
-    public function getStringHeaders()
+    public function getStringHeaders(): array
     {
         $value = $this->getExpectedFieldValue();
         return [
@@ -115,7 +115,7 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getStringHeaders
      */
-    public function testDeserializationFromString($headerLine, $class)
+    public function testDeserializationFromString($headerLine, $class): void
     {
         $callback = sprintf('%s::fromString', $class);
         $header   = $callback($headerLine);
@@ -136,7 +136,7 @@ class AddressListHeaderTest extends TestCase
         $this->assertEquals('Last, First', $address->getName());
     }
 
-    public function getStringHeadersWithNoWhitespaceSeparator()
+    public function getStringHeadersWithNoWhitespaceSeparator(): array
     {
         $value = $this->getExpectedFieldValue();
         return [
@@ -151,7 +151,7 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getHeadersWithComments
      */
-    public function testDeserializationFromStringWithComments($value)
+    public function testDeserializationFromStringWithComments($value): void
     {
         $header = From::fromString($value);
         $list = $header->getAddressList();
@@ -159,7 +159,7 @@ class AddressListHeaderTest extends TestCase
         $this->assertTrue($list->has('user@example.com'));
     }
 
-    public function getHeadersWithComments()
+    public function getHeadersWithComments(): array
     {
         return [
             ['From: user@example.com (Comment)'],
@@ -172,7 +172,7 @@ class AddressListHeaderTest extends TestCase
      * @group 3789
      * @dataProvider getStringHeadersWithNoWhitespaceSeparator
      */
-    public function testAllowsNoWhitespaceBetweenHeaderAndValue($headerLine, $class)
+    public function testAllowsNoWhitespaceBetweenHeaderAndValue($headerLine, $class): void
     {
         $callback = sprintf('%s::fromString', $class);
         $header   = $callback($headerLine);
@@ -196,7 +196,7 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider getAddressListsWithGroup
      */
-    public function testAddressListWithGroup($input, $count, $sample)
+    public function testAddressListWithGroup($input, $count, $sample): void
     {
         $header = To::fromString($input);
         $list = $header->getAddressList();
@@ -206,7 +206,7 @@ class AddressListHeaderTest extends TestCase
         }
     }
 
-    public function getAddressListsWithGroup()
+    public function getAddressListsWithGroup(): array
     {
         return [
             ['To: undisclosed-recipients:;', 0, null],
@@ -214,7 +214,7 @@ class AddressListHeaderTest extends TestCase
         ];
     }
 
-    public function specialCharHeaderProvider()
+    public function specialCharHeaderProvider(): array
     {
         return [
             [
@@ -233,7 +233,7 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider specialCharHeaderProvider
      */
-    public function testDeserializationFromSpecialCharString($headerLine, $expected, $encoding)
+    public function testDeserializationFromSpecialCharString($headerLine, $expected, $encoding): void
     {
         $header = To::fromString($headerLine);
 

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -20,7 +20,7 @@ use Laminas\Mail\Header\UnstructuredInterface;
  */
 class ContentDispositionTest extends TestCase
 {
-    public function testImplementsHeaderInterface()
+    public function testImplementsHeaderInterface(): void
     {
         $header = new ContentDisposition();
 
@@ -28,7 +28,7 @@ class ContentDispositionTest extends TestCase
         $this->assertInstanceOf(HeaderInterface::class, $header);
     }
 
-    public function testTrailingSemiColonFromString()
+    public function testTrailingSemiColonFromString(): void
     {
         $contentTypeHeader = ContentDisposition::fromString(
             'Content-Disposition: attachment; filename="test-case.txt";'
@@ -37,7 +37,7 @@ class ContentDispositionTest extends TestCase
         $this->assertEquals(['filename' => 'test-case.txt'], $params);
     }
 
-    public static function getLiteralData()
+    public static function getLiteralData(): array
     {
         return [
             [
@@ -58,7 +58,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider getLiteralData
      */
-    public function testHandlesLiterals($expected, $header)
+    public function testHandlesLiterals($expected, $header): void
     {
         $header = ContentDisposition::fromString('Content-Disposition: ' . $header);
         $this->assertEquals($expected, $header->getParameters());
@@ -67,7 +67,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider setDispositionProvider
      */
-    public function testFromString($disposition, $parameters, $fieldValue, $expectedToString)
+    public function testFromString($disposition, $parameters, $fieldValue, $expectedToString): void
     {
         $header = ContentDisposition::fromString($expectedToString);
 
@@ -82,7 +82,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider setDispositionProvider
      */
-    public function testSetDisposition($disposition, $parameters, $fieldValue, $expectedToString)
+    public function testSetDisposition($disposition, $parameters, $fieldValue, $expectedToString): void
     {
         $header = new ContentDisposition();
 
@@ -98,7 +98,7 @@ class ContentDispositionTest extends TestCase
         $this->assertEquals($expectedToString, $header->toString(), 'toString() value not match');
     }
 
-    public function testGetSetEncoding()
+    public function testGetSetEncoding(): void
     {
         $header = new ContentDisposition();
 
@@ -115,14 +115,14 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider invalidHeaderLinesProvider
      */
-    public function testFromStringThrowException($headerLine, $expectedException, $exceptionMessage)
+    public function testFromStringThrowException($headerLine, $expectedException, $exceptionMessage): void
     {
         $this->expectException($expectedException);
         $this->expectExceptionMessage($exceptionMessage);
         ContentDisposition::fromString($headerLine);
     }
 
-    public function testFromStringHandlesContinuations()
+    public function testFromStringHandlesContinuations(): void
     {
         $header = ContentDisposition::fromString("Content-Disposition: attachment;\r\n level=1");
         $this->assertEquals('attachment', $header->getDisposition());
@@ -132,7 +132,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider invalidParametersProvider
      */
-    public function testSetParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage)
+    public function testSetParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage): void
     {
         $header = new ContentDisposition();
         $header->setDisposition('attachment');
@@ -145,13 +145,13 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider getParameterProvider
      */
-    public function testGetParameter($fromString, $paramName, $paramValue)
+    public function testGetParameter($fromString, $paramName, $paramValue): void
     {
         $header = ContentDisposition::fromString($fromString);
         $this->assertEquals($paramValue, $header->getParameter($paramName));
     }
 
-    public function testRemoveParameter()
+    public function testRemoveParameter(): void
     {
         $header = ContentDisposition::fromString('Content-Disposition: inline');
 
@@ -161,7 +161,7 @@ class ContentDispositionTest extends TestCase
         $this->assertEquals(true, $header->removeParameter('name'));
     }
 
-    public function setDispositionProvider()
+    public function setDispositionProvider(): array
     {
         // @codingStandardsIgnoreStart
         $foldingFieldValue = "attachment;\r\n filename=\"this-test-filename-is-long-enough-to-flow-to-two-lines.txt\"";
@@ -201,7 +201,7 @@ class ContentDispositionTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function invalidParametersProvider()
+    public function invalidParametersProvider(): array
     {
         $invalidArgumentException = InvalidArgumentException::class;
 
@@ -214,7 +214,7 @@ class ContentDispositionTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function invalidHeaderLinesProvider()
+    public function invalidHeaderLinesProvider(): array
     {
         $invalidArgumentException = InvalidArgumentException::class;
 
@@ -231,7 +231,7 @@ class ContentDispositionTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function getParameterProvider()
+    public function getParameterProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -42,15 +42,15 @@ class ContentDispositionTest extends TestCase
         return [
             [
                 ['filename' => 'foo; bar.txt'],
-                'attachment; filename="foo; bar.txt"'
+                'attachment; filename="foo; bar.txt"',
             ],
             [
                 ['filename' => 'foo&bar.txt'],
-                'attachment; filename="foo&bar.txt"'
+                'attachment; filename="foo&bar.txt"',
             ],
             [
                 [],
-                'inline'
+                'inline',
             ],
         ];
     }
@@ -226,7 +226,7 @@ class ContentDispositionTest extends TestCase
             'newline' => ["Content-Disposition: inline;\nlevel=1", $invalidArgumentException, 'header value'],
             'cr-lf' => ["Content-Disposition: inline\r\n;level=1", $invalidArgumentException, 'header value'],
             'multiline' => ["Content-Disposition: inline;\r\nlevel=1\r\nq=0.1", $invalidArgumentException, 'header value'],
-            'incomplete sequence' => ["Content-Disposition: attachment;\r\n filename*0=\"first-part\";\r\n filename*2=\"third-part\"", $invalidArgumentException, 'incomplete continuation']
+            'incomplete sequence' => ["Content-Disposition: attachment;\r\n filename*0=\"first-part\";\r\n filename*2=\"third-part\"", $invalidArgumentException, 'incomplete continuation'],
         ];
         // @codingStandardsIgnoreEnd
     }
@@ -242,7 +242,7 @@ class ContentDispositionTest extends TestCase
                 "Content-Disposition: attachment;\r\n filename*0=\"this-file-name-is-so-long-that-it-does-not-even\";\r\n filename*1=\"-fit-on-a-whole-line-by-itself-so-we-need-to-sp\";\r\n filename*2=\"lit-it-with-value-continuation.txt\"",
                 'filename',
                 'this-file-name-is-so-long-that-it-does-not-even-fit-on-a-whole-line-by-itself-so-we-need-to-split-it-with-value-continuation.txt',
-            ]
+            ],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ContentTransferEncodingTest extends TestCase
 {
-    public function dataValidEncodings()
+    public function dataValidEncodings(): array
     {
         return [
             ['7bit'],
@@ -29,7 +29,7 @@ class ContentTransferEncodingTest extends TestCase
         ];
     }
 
-    public function dataInvalidEncodings()
+    public function dataInvalidEncodings(): array
     {
         return [
             ['9bit'],
@@ -40,7 +40,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider dataValidEncodings
      */
-    public function testContentTransferEncodingFromStringCreatesValidContentTransferEncodingHeader($encoding)
+    public function testContentTransferEncodingFromStringCreatesValidContentTransferEncodingHeader($encoding): void
     {
         $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: '.$encoding);
         $this->assertInstanceOf(HeaderInterface::class, $contentTransferEncodingHeader);
@@ -50,13 +50,13 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider dataInvalidEncodings
      */
-    public function testContentTransferEncodingFromStringRaisesException($encoding)
+    public function testContentTransferEncodingFromStringRaisesException($encoding): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: '.$encoding);
     }
 
-    public function testContentTransferEncodingGetFieldNameReturnsHeaderName()
+    public function testContentTransferEncodingGetFieldNameReturnsHeaderName(): void
     {
         $contentTransferEncodingHeader = new ContentTransferEncoding();
         $this->assertEquals('Content-Transfer-Encoding', $contentTransferEncodingHeader->getFieldName());
@@ -65,7 +65,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider dataValidEncodings
      */
-    public function testContentTransferEncodingGetFieldValueReturnsProperValue($encoding)
+    public function testContentTransferEncodingGetFieldValueReturnsProperValue($encoding): void
     {
         $contentTransferEncodingHeader = new ContentTransferEncoding();
         $contentTransferEncodingHeader->setTransferEncoding($encoding);
@@ -76,7 +76,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider dataValidEncodings
      */
-    public function testContentTransferEncodingHandlesCaseInsensitivity($encoding)
+    public function testContentTransferEncodingHandlesCaseInsensitivity($encoding): void
     {
         $header = new ContentTransferEncoding();
         $header->setTransferEncoding(strtoupper(substr($encoding, 0, 4)).substr($encoding, 4));
@@ -86,14 +86,14 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider dataValidEncodings
      */
-    public function testContentTransferEncodingToStringReturnsHeaderFormattedString($encoding)
+    public function testContentTransferEncodingToStringReturnsHeaderFormattedString($encoding): void
     {
         $contentTransferEncodingHeader = new ContentTransferEncoding();
         $contentTransferEncodingHeader->setTransferEncoding($encoding);
         $this->assertEquals("Content-Transfer-Encoding: ".$encoding, $contentTransferEncodingHeader->toString());
     }
 
-    public function testProvidingParametersIntroducesHeaderFolding()
+    public function testProvidingParametersIntroducesHeaderFolding(): void
     {
         $header = new ContentTransferEncoding();
         $header->setTransferEncoding('quoted-printable');
@@ -105,13 +105,13 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testFromStringRaisesExceptionOnInvalidHeaderName()
+    public function testFromStringRaisesExceptionOnInvalidHeaderName(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         ContentTransferEncoding::fromString('Content-Transfer-Encoding' . chr(32) . ': 8bit');
     }
 
-    public function headerLines()
+    public function headerLines(): array
     {
         return [
             'newline' => ["Content-Transfer-Encoding: 8bit\n7bit"],
@@ -124,7 +124,7 @@ class ContentTransferEncodingTest extends TestCase
      * @dataProvider headerLines
      * @group ZF2015-04
      */
-    public function testFromStringRaisesExceptionForInvalidMultilineValues($headerLine)
+    public function testFromStringRaisesExceptionForInvalidMultilineValues($headerLine): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         ContentTransferEncoding::fromString($headerLine);
@@ -133,7 +133,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testFromStringRaisesExceptionForContinuations()
+    public function testFromStringRaisesExceptionForContinuations(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('expects');
@@ -143,7 +143,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testSetTransferEncodingRaisesExceptionForInvalidValues()
+    public function testSetTransferEncodingRaisesExceptionForInvalidValues(): void
     {
         $header = new ContentTransferEncoding();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -151,20 +151,20 @@ class ContentTransferEncodingTest extends TestCase
         $header->setTransferEncoding("8bit\r\n 7bit");
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for Content-Transfer-Encoding string');
         ContentTransferEncoding::fromString('Foo: bar');
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new ContentTransferEncoding();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testChangeEncodingHasNoEffect()
+    public function testChangeEncodingHasNoEffect(): void
     {
         $header = new ContentTransferEncoding();
         $header->setEncoding('UTF-8');

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -160,13 +160,13 @@ class ContentTransferEncodingTest extends TestCase
 
     public function testDefaultEncoding()
     {
-        $header = new ContentTransferEncoding('today');
+        $header = new ContentTransferEncoding();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
     public function testChangeEncodingHasNoEffect()
     {
-        $header = new ContentTransferEncoding('today');
+        $header = new ContentTransferEncoding();
         $header->setEncoding('UTF-8');
         $this->assertSame('ASCII', $header->getEncoding());
     }

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -51,11 +51,11 @@ class ContentTypeTest extends TestCase
         return [
             [
                 ['name' => 'foo; bar.txt'],
-                'text/plain; name="foo; bar.txt"'
+                'text/plain; name="foo; bar.txt"',
             ],
             [
                 ['name' => 'foo&bar.txt'],
-                'text/plain; name="foo&bar.txt"'
+                'text/plain; name="foo&bar.txt"',
             ],
         ];
     }

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -197,13 +197,13 @@ class ContentTypeTest extends TestCase
 
     public function testDefaultEncoding()
     {
-        $header = new ContentType('today');
+        $header = new ContentType();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
     public function testSetEncoding()
     {
-        $header = new ContentType('today');
+        $header = new ContentType();
         $header->setEncoding('UTF-8');
         $this->assertSame('UTF-8', $header->getEncoding());
     }

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ContentTypeTest extends TestCase
 {
-    public function testImplementsHeaderInterface()
+    public function testImplementsHeaderInterface(): void
     {
         $header = new ContentType();
 
@@ -31,7 +31,7 @@ class ContentTypeTest extends TestCase
     /**
      * @group 6491
      */
-    public function testTrailingSemiColonFromString()
+    public function testTrailingSemiColonFromString(): void
     {
         $contentTypeHeader = ContentType::fromString(
             'Content-Type: multipart/alternative; boundary="Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD";'
@@ -40,13 +40,13 @@ class ContentTypeTest extends TestCase
         $this->assertEquals(['boundary' => 'Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD'], $params);
     }
 
-    public function testExtractsExtraInformationWithoutBeingConfusedByTrailingSemicolon()
+    public function testExtractsExtraInformationWithoutBeingConfusedByTrailingSemicolon(): void
     {
         $header = ContentType::fromString('Content-Type: application/pdf;name="foo.pdf";');
         $this->assertEquals($header->getParameters(), ['name' => 'foo.pdf']);
     }
 
-    public static function getLiteralData()
+    public static function getLiteralData(): array
     {
         return [
             [
@@ -63,7 +63,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider getLiteralData
      */
-    public function testHandlesLiterals(array $expected, $header)
+    public function testHandlesLiterals(array $expected, $header): void
     {
         $header = ContentType::fromString('Content-Type: '.$header);
         $this->assertEquals($expected, $header->getParameters());
@@ -72,7 +72,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider setTypeProvider
      */
-    public function testFromString($type, $parameters, $fieldValue, $expectedToString)
+    public function testFromString($type, $parameters, $fieldValue, $expectedToString): void
     {
         $header = ContentType::fromString($expectedToString);
 
@@ -87,7 +87,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider setTypeProvider
      */
-    public function testSetType($type, $parameters, $fieldValue, $expectedToString)
+    public function testSetType($type, $parameters, $fieldValue, $expectedToString): void
     {
         $header = new ContentType();
 
@@ -106,7 +106,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider invalidHeaderLinesProvider
      */
-    public function testFromStringThrowException($headerLine, $expectedException, $exceptionMessage)
+    public function testFromStringThrowException($headerLine, $expectedException, $exceptionMessage): void
     {
         $this->expectException($expectedException);
         $this->expectExceptionMessage($exceptionMessage);
@@ -116,7 +116,7 @@ class ContentTypeTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testFromStringHandlesContinuations()
+    public function testFromStringHandlesContinuations(): void
     {
         $header = ContentType::fromString("Content-Type: text/html;\r\n level=1");
         $this->assertEquals('text/html', $header->getType());
@@ -126,7 +126,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider invalidParametersProvider
      */
-    public function testAddParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage)
+    public function testAddParameterThrowException($paramName, $paramValue, $expectedException, $exceptionMessage): void
     {
         $header = new ContentType();
         $header->setType('text/html');
@@ -136,7 +136,7 @@ class ContentTypeTest extends TestCase
         $header->addParameter($paramName, $paramValue);
     }
 
-    public function setTypeProvider()
+    public function setTypeProvider(): array
     {
         $foldingHeaderLine = "Content-Type: foo/baz;\r\n charset=\"us-ascii\"";
         $foldingFieldValue = "foo/baz;\r\n charset=\"us-ascii\"";
@@ -157,7 +157,7 @@ class ContentTypeTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function invalidParametersProvider()
+    public function invalidParametersProvider(): array
     {
         $invalidArgumentException = Exception\InvalidArgumentException::class;
 
@@ -171,7 +171,7 @@ class ContentTypeTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function invalidHeaderLinesProvider()
+    public function invalidHeaderLinesProvider(): array
     {
         $invalidArgumentException = Exception\InvalidArgumentException::class;
 
@@ -188,27 +188,27 @@ class ContentTypeTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for Content-Type string');
         ContentType::fromString('Foo: bar');
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new ContentType();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncoding()
+    public function testSetEncoding(): void
     {
         $header = new ContentType();
         $header->setEncoding('UTF-8');
         $this->assertSame('UTF-8', $header->getEncoding());
     }
 
-    public function testSetTypeThrowsOnInvalidValue()
+    public function testSetTypeThrowsOnInvalidValue(): void
     {
         $header = new ContentType();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -216,31 +216,31 @@ class ContentTypeTest extends TestCase
         $header->setType('invalid');
     }
 
-    public function testGetParameter()
+    public function testGetParameter(): void
     {
         $header = ContentType::fromString('content-type: text/plain; level=top');
         $this->assertSame('top', $header->getParameter('level'));
     }
 
-    public function testGetParameterWithSpaceTrimmed()
+    public function testGetParameterWithSpaceTrimmed(): void
     {
         $header = ContentType::fromString('content-type: text/plain; level=top; name="logfile.log";');
         $this->assertSame('logfile.log', $header->getParameter('name'));
     }
 
-    public function testGetParameterNotExists()
+    public function testGetParameterNotExists(): void
     {
         $header = ContentType::fromString('content-type: text/plain');
         $this->assertNull($header->getParameter('level'));
     }
 
-    public function testRemoveParameter()
+    public function testRemoveParameter(): void
     {
         $header = ContentType::fromString('content-type: text/plain; level=top');
         $this->assertTrue($header->removeParameter('level'));
     }
 
-    public function testRemoveParameterNotExists()
+    public function testRemoveParameterNotExists(): void
     {
         $header = ContentType::fromString('content-type: text/plain');
         $this->assertFalse($header->removeParameter('level'));

--- a/test/Header/DateTest.php
+++ b/test/Header/DateTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DateTest extends TestCase
 {
-    public function headerLines()
+    public function headerLines(): array
     {
         return [
             'newline'      => ["Date: xxx yyy\n"],
@@ -31,7 +31,7 @@ class DateTest extends TestCase
      * @dataProvider headerLines
      * @group ZF2015-04
      */
-    public function testFromStringRaisesExceptionOnCrlfInjectionAttempt($header)
+    public function testFromStringRaisesExceptionOnCrlfInjectionAttempt($header): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         Header\Date::fromString($header);
@@ -40,33 +40,33 @@ class DateTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testPreventsCRLFInjectionViaConstructor()
+    public function testPreventsCRLFInjectionViaConstructor(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $address = new Header\Date("This\ris\r\na\nCRLF Attack");
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for Date string');
         Header\Date::fromString('Foo: bar');
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new Header\Date('today');
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncodingHasNoEffect()
+    public function testSetEncodingHasNoEffect(): void
     {
         $header = new Header\Date('today');
         $header->setEncoding('UTF-8');
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $header = new Header\Date('today');
         $this->assertEquals('Date: today', $header->toString());

--- a/test/Header/GenericHeaderTest.php
+++ b/test/Header/GenericHeaderTest.php
@@ -184,7 +184,7 @@ class GenericHeaderTest extends TestCase
 
     public function testToStringThrowsWithoutFieldName()
     {
-        $header = new GenericHeader;
+        $header = new GenericHeader();
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Header name is not set, use setFieldName()');

--- a/test/Header/GenericHeaderTest.php
+++ b/test/Header/GenericHeaderTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class GenericHeaderTest extends TestCase
 {
-    public function invalidHeaderLines()
+    public function invalidHeaderLines(): array
     {
         return [
             'append-chr-32' => [
@@ -39,14 +39,14 @@ class GenericHeaderTest extends TestCase
      * @dataProvider invalidHeaderLines
      * @group ZF2015-04
      */
-    public function testSplitHeaderLineRaisesExceptionOnInvalidHeader($line, $message)
+    public function testSplitHeaderLineRaisesExceptionOnInvalidHeader($line, $message): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
         GenericHeader::splitHeaderLine($line);
     }
 
-    public function fieldNames()
+    public function fieldNames(): array
     {
         return [
             'append-chr-13'  => ["Subject" . chr(13)],
@@ -59,7 +59,7 @@ class GenericHeaderTest extends TestCase
      * @dataProvider fieldNames
      * @group ZF2015-04
      */
-    public function testRaisesExceptionOnInvalidFieldName($fieldName)
+    public function testRaisesExceptionOnInvalidFieldName($fieldName): void
     {
         $header = new GenericHeader();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -67,7 +67,7 @@ class GenericHeaderTest extends TestCase
         $header->setFieldName($fieldName);
     }
 
-    public function fieldValues()
+    public function fieldValues(): array
     {
         return [
             'empty-lines'             => ["\n\n\r\n\r\n\n"],
@@ -86,7 +86,7 @@ class GenericHeaderTest extends TestCase
      * @group ZF2015-04
      * @param string $fieldValue
      */
-    public function testCRLFsequencesAreEncodedOnToString($fieldValue)
+    public function testCRLFsequencesAreEncodedOnToString($fieldValue): void
     {
         $header = new GenericHeader('Foo');
         $header->setFieldValue($fieldValue);
@@ -103,7 +103,7 @@ class GenericHeaderTest extends TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testParseValidSubjectHeader($decodedValue, $encodedValue, $encoding)
+    public function testParseValidSubjectHeader($decodedValue, $encodedValue, $encoding): void
     {
         $header = GenericHeader::fromString('Foo:' . $encodedValue);
 
@@ -118,7 +118,7 @@ class GenericHeaderTest extends TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testSetFieldValueValidValue($decodedValue, $encodedValue, $encoding)
+    public function testSetFieldValueValidValue($decodedValue, $encodedValue, $encoding): void
     {
         $header = new GenericHeader('Foo');
         $header->setFieldValue($decodedValue);
@@ -128,7 +128,7 @@ class GenericHeaderTest extends TestCase
         $this->assertEquals($encoding, $header->getEncoding());
     }
 
-    public function validFieldValuesProvider()
+    public function validFieldValuesProvider(): array
     {
         return [
             // Description => [decoded format, encoded format, encoding],
@@ -149,7 +149,7 @@ class GenericHeaderTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testCastingToStringHandlesContinuationsProperly()
+    public function testCastingToStringHandlesContinuationsProperly(): void
     {
         $encoded = '=?UTF-8?Q?foo=0D=0A=20bar?=';
         $raw = "foo\r\n bar";
@@ -162,27 +162,27 @@ class GenericHeaderTest extends TestCase
         $this->assertEquals('Foo: ' . $encoded, $header->toString());
     }
 
-    public function testAllowZeroInHeaderValueInConstructor()
+    public function testAllowZeroInHeaderValueInConstructor(): void
     {
         $header = new GenericHeader('Foo', 0);
         $this->assertEquals(0, $header->getFieldValue());
         $this->assertEquals('Foo: 0', $header->toString());
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new GenericHeader('Foo');
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncoding()
+    public function testSetEncoding(): void
     {
         $header = new GenericHeader('Foo');
         $header->setEncoding('UTF-8');
         $this->assertSame('UTF-8', $header->getEncoding());
     }
 
-    public function testToStringThrowsWithoutFieldName()
+    public function testToStringThrowsWithoutFieldName(): void
     {
         $header = new GenericHeader();
 
@@ -191,7 +191,7 @@ class GenericHeaderTest extends TestCase
         $header->toString();
     }
 
-    public function testChangeEncodingToAsciiNotAllowedWhenHeaderValueContainsUtf8Characters()
+    public function testChangeEncodingToAsciiNotAllowedWhenHeaderValueContainsUtf8Characters(): void
     {
         $subject = new GenericHeader();
         $subject->setFieldValue('Accents òàùèéì');
@@ -202,7 +202,7 @@ class GenericHeaderTest extends TestCase
         self::assertSame('UTF-8', $subject->getEncoding());
     }
 
-    public function testChangeEncodingBackToAscii()
+    public function testChangeEncodingBackToAscii(): void
     {
         $subject = new GenericHeader('X-Test');
         $subject->setFieldValue('test');
@@ -216,7 +216,7 @@ class GenericHeaderTest extends TestCase
         self::assertSame('ASCII', $subject->getEncoding());
     }
 
-    public function testSetNullEncoding()
+    public function testSetNullEncoding(): void
     {
         $subject = GenericHeader::fromString('X-Test: test');
         self::assertSame('ASCII', $subject->getEncoding());
@@ -225,7 +225,7 @@ class GenericHeaderTest extends TestCase
         self::assertSame('ASCII', $subject->getEncoding());
     }
 
-    public function testSettingFieldValueCanChangeEncoding()
+    public function testSettingFieldValueCanChangeEncoding(): void
     {
         $subject = GenericHeader::fromString('X-Test: test');
         self::assertSame('ASCII', $subject->getEncoding());
@@ -234,7 +234,7 @@ class GenericHeaderTest extends TestCase
         self::assertSame('UTF-8', $subject->getEncoding());
     }
 
-    public function testSettingTheSameEncoding()
+    public function testSettingTheSameEncoding(): void
     {
         $subject = GenericHeader::fromString('X-Test: test');
         self::assertSame('ASCII', $subject->getEncoding());

--- a/test/Header/GenericMultiHeaderTest.php
+++ b/test/Header/GenericMultiHeaderTest.php
@@ -17,13 +17,13 @@ use PHPUnit\Framework\TestCase;
  */
 class GenericMultiHeaderTest extends TestCase
 {
-    public function testFromStringSingle()
+    public function testFromStringSingle(): void
     {
         $multiHeader = GenericMultiHeader::fromString('x-custom: test');
         $this->assertSame(GenericMultiHeader::class, \get_class($multiHeader));
     }
 
-    public function testFromStringMultiple()
+    public function testFromStringMultiple(): void
     {
         $headers = GenericMultiHeader::fromString('x-custom: foo,bar');
         $this->assertSame(2, \count($headers));
@@ -32,14 +32,14 @@ class GenericMultiHeaderTest extends TestCase
         }
     }
 
-    public function testToStringSingle()
+    public function testToStringSingle(): void
     {
         $multiHeader = new GenericMultiHeader('x-custom', 'test');
 
         $this->assertSame('X-Custom: test', $multiHeader->toStringMultipleHeaders([]));
     }
 
-    public function testToStringMultiple()
+    public function testToStringMultiple(): void
     {
         $multiHeader = new GenericMultiHeader('x-custom', 'test');
         $anotherHeader = new GenericMultiHeader('x-custom', 'two');
@@ -47,7 +47,7 @@ class GenericMultiHeaderTest extends TestCase
         $this->assertSame('X-Custom: test,two', $multiHeader->toStringMultipleHeaders([$anotherHeader]));
     }
 
-    public function testToStringInvalid()
+    public function testToStringInvalid(): void
     {
         $multiHeader = new GenericMultiHeader('x-custom', 'test');
 

--- a/test/Header/HeaderLocatorTest.php
+++ b/test/Header/HeaderLocatorTest.php
@@ -18,12 +18,12 @@ class HeaderLocatorTest extends TestCase
      */
     private $headerLocator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->headerLocator = new Header\HeaderLocator();
     }
 
-    public function provideHeaderNames()
+    public function provideHeaderNames(): array
     {
         return [
             'with existing name'     => ['to', Header\To::class],
@@ -38,12 +38,12 @@ class HeaderLocatorTest extends TestCase
      * @param $default
      * @dataProvider provideHeaderNames
      */
-    public function testHeaderIsProperlyLoaded($name, $expected, $default = null)
+    public function testHeaderIsProperlyLoaded($name, $expected, $default = null): void
     {
         $this->assertEquals($expected, $this->headerLocator->get($name, $default));
     }
 
-    public function testHeaderExistenceIsProperlyChecked()
+    public function testHeaderExistenceIsProperlyChecked(): void
     {
         $this->assertTrue($this->headerLocator->has('to'));
         $this->assertTrue($this->headerLocator->has('To'));
@@ -53,21 +53,21 @@ class HeaderLocatorTest extends TestCase
         $this->assertFalse($this->headerLocator->has('bar'));
     }
 
-    public function testHeaderCanBeAdded()
+    public function testHeaderCanBeAdded(): void
     {
         $this->assertFalse($this->headerLocator->has('foo'));
         $this->headerLocator->add('foo', Header\GenericHeader::class);
         $this->assertTrue($this->headerLocator->has('foo'));
     }
 
-    public function testHeaderCanBeRemoved()
+    public function testHeaderCanBeRemoved(): void
     {
         $this->assertTrue($this->headerLocator->has('to'));
         $this->headerLocator->remove('to');
         $this->assertFalse($this->headerLocator->has('to'));
     }
 
-    public static function expectedHeaders()
+    public static function expectedHeaders(): array
     {
         return [
             'bcc'          => ['bcc', Header\Bcc::class],
@@ -95,7 +95,7 @@ class HeaderLocatorTest extends TestCase
      * @param string $name
      * @param Header\HeaderInterface $class
      */
-    public function testDefaultHeadersMapResolvesProperHeader($name, $class)
+    public function testDefaultHeadersMapResolvesProperHeader($name, $class): void
     {
         $this->assertEquals($class, $this->headerLocator->get($name));
     }

--- a/test/Header/HeaderNameTest.php
+++ b/test/Header/HeaderNameTest.php
@@ -20,7 +20,7 @@ class HeaderNameTest extends TestCase
     /**
      * Data for filter name
      */
-    public function getFilterNames()
+    public function getFilterNames(): array
     {
         return [
             ['Subject', 'Subject'],
@@ -37,13 +37,13 @@ class HeaderNameTest extends TestCase
      * @dataProvider getFilterNames
      * @group ZF2015-04
      */
-    public function testFilterName($name, $expected)
+    public function testFilterName($name, $expected): void
     {
         HeaderName::assertValid($expected);
         $this->assertEquals($expected, HeaderName::filter($name));
     }
 
-    public function validateNames()
+    public function validateNames(): array
     {
         return [
             ['Subject', 'assertTrue'],
@@ -60,12 +60,12 @@ class HeaderNameTest extends TestCase
      * @dataProvider validateNames
      * @group ZF2015-04
      */
-    public function testValidateName($name, $assertion)
+    public function testValidateName($name, $assertion): void
     {
         $this->{$assertion}(HeaderName::isValid($name));
     }
 
-    public function assertNames()
+    public function assertNames(): array
     {
         return [
             ['Subject:'],
@@ -79,7 +79,7 @@ class HeaderNameTest extends TestCase
      * @dataProvider assertNames
      * @group ZF2015-04
      */
-    public function testAssertValidRaisesExceptionForInvalidNames($name)
+    public function testAssertValidRaisesExceptionForInvalidNames($name): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Invalid');

--- a/test/Header/HeaderValueTest.php
+++ b/test/Header/HeaderValueTest.php
@@ -20,7 +20,7 @@ class HeaderValueTest extends TestCase
     /**
      * Data for filter value
      */
-    public function getFilterValues()
+    public function getFilterValues(): array
     {
         return [
             ["This is a\n test", "This is a test"],
@@ -42,12 +42,12 @@ class HeaderValueTest extends TestCase
      * @dataProvider getFilterValues
      * @group ZF2015-04
      */
-    public function testFilterValue($value, $expected)
+    public function testFilterValue($value, $expected): void
     {
         $this->assertEquals($expected, HeaderValue::filter($value));
     }
 
-    public function validateValues()
+    public function validateValues(): array
     {
         return [
             ["This is a\n test", 'assertFalse'],
@@ -73,12 +73,12 @@ class HeaderValueTest extends TestCase
      * @dataProvider validateValues
      * @group ZF2015-04
      */
-    public function testValidateValue($value, $assertion)
+    public function testValidateValue($value, $assertion): void
     {
         $this->{$assertion}(HeaderValue::isValid($value));
     }
 
-    public function assertValues()
+    public function assertValues(): array
     {
         return [
             ["This is a\n test"],
@@ -98,7 +98,7 @@ class HeaderValueTest extends TestCase
      * @dataProvider assertValues
      * @group ZF2015-04
      */
-    public function testAssertValidRaisesExceptionForInvalidValues($value)
+    public function testAssertValidRaisesExceptionForInvalidValues($value): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Invalid');

--- a/test/Header/HeaderWrapTest.php
+++ b/test/Header/HeaderWrapTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HeaderWrapTest extends TestCase
 {
-    public function testWrapUnstructuredHeaderAscii()
+    public function testWrapUnstructuredHeaderAscii(): void
     {
         $string = str_repeat('foobarblahblahblah baz bat', 4);
         $header = $this->createMock(UnstructuredInterface::class);
@@ -35,7 +35,7 @@ class HeaderWrapTest extends TestCase
     /**
      * @group Laminas-258
      */
-    public function testWrapUnstructuredHeaderMime()
+    public function testWrapUnstructuredHeaderMime(): void
     {
         $string = str_repeat('foobarblahblahblah baz bat', 3);
         $header = $this->createMock(UnstructuredInterface::class);
@@ -50,7 +50,7 @@ class HeaderWrapTest extends TestCase
         $this->assertEquals($string, iconv_mime_decode($test, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8'));
     }
 
-    public function testWrapUnknownHeaderType()
+    public function testWrapUnknownHeaderType(): void
     {
         $header = new \Laminas\Mail\Header\Bcc('test@example.org');
         $value = 'value unmodified by wrap function';
@@ -60,7 +60,7 @@ class HeaderWrapTest extends TestCase
     /**
      * @group Laminas-359
      */
-    public function testMimeEncoding()
+    public function testMimeEncoding(): void
     {
         $string   = 'Umlauts: ä';
         $expected = '=?UTF-8?Q?Umlauts:=20=C3=A4?=';
@@ -70,7 +70,7 @@ class HeaderWrapTest extends TestCase
         $this->assertEquals($string, iconv_mime_decode($test, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8'));
     }
 
-    public function testMimeDecoding()
+    public function testMimeDecoding(): void
     {
         $expected = str_repeat('foobarblahblahblah baz bat', 3);
         $encoded = "=?UTF-8?Q?foobarblahblahblah=20baz=20batfoobarblahblahblah=20baz=20?=\r\n"
@@ -86,7 +86,7 @@ class HeaderWrapTest extends TestCase
      * because undocumented behavior in iconv_mime_decode()
      * @see https://github.com/zendframework/zend-mail/pull/187
      */
-    public function testMimeDecodeBreakageBug()
+    public function testMimeDecodeBreakageBug(): void
     {
         $headerValue = 'v=1; a=rsa-sha25; c=relaxed/simple; d=example.org; h='
             . "\r\n\t" . 'content-language:content-type:content-type:in-reply-to';
@@ -113,7 +113,7 @@ class HeaderWrapTest extends TestCase
      * which can be triggered as:
      *   $header = new GenericHeader($name, $value);
      */
-    public function testCanBeEncoded()
+    public function testCanBeEncoded(): void
     {
         // @codingStandardsIgnoreStart
         $value   = "[#77675] New Issue:xxxxxxxxx xxxxxxx xxxxxxxx xxxxxxxxxxxxx xxxxxxxxxx xxxxxxxx, tähtaeg xx.xx, xxxx";
@@ -126,7 +126,7 @@ class HeaderWrapTest extends TestCase
     /**
      * @requires extension imap
      */
-    public function testMultilineWithMultibyteSplitAcrossCharacter()
+    public function testMultilineWithMultibyteSplitAcrossCharacter(): void
     {
         $originalValue = 'аф';
 

--- a/test/Header/IdentificationFieldTest.php
+++ b/test/Header/IdentificationFieldTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class IdentificationFieldTest extends TestCase
 {
-    public function stringHeadersProvider()
+    public function stringHeadersProvider(): array
     {
         return array_merge(
             [
@@ -30,7 +30,7 @@ class IdentificationFieldTest extends TestCase
         );
     }
 
-    public function reversibleStringHeadersProvider()
+    public function reversibleStringHeadersProvider(): array
     {
         return [
             [References::class, 'References: <1234@local.machine.example>', ['1234@local.machine.example']],
@@ -43,7 +43,7 @@ class IdentificationFieldTest extends TestCase
         ];
     }
 
-    public function invalidIds()
+    public function invalidIds(): array
     {
         return [
             [References::class, ["1234@local.machine.example\r\n"]],
@@ -58,7 +58,7 @@ class IdentificationFieldTest extends TestCase
      * @param string $headerString
      * @param string[] $ids
      */
-    public function testDeserializationFromString($className, $headerString, $ids)
+    public function testDeserializationFromString($className, $headerString, $ids): void
     {
         /** @var IdentificationField $header */
         $header = $className::fromString($headerString);
@@ -71,7 +71,7 @@ class IdentificationFieldTest extends TestCase
      * @param string $headerString
      * @param string[] $ids
      */
-    public function testSerializationToString($className, $headerString, $ids)
+    public function testSerializationToString($className, $headerString, $ids): void
     {
         /** @var IdentificationField $header */
         $header = new $className();
@@ -85,7 +85,7 @@ class IdentificationFieldTest extends TestCase
      * @param string $headerString
      * @param string[] $ids
      */
-    public function testDefaultEncoding($className, $headerString, array $ids)
+    public function testDefaultEncoding($className, $headerString, array $ids): void
     {
         /** @var IdentificationField $header */
         $header = $className::fromString($headerString);
@@ -98,7 +98,7 @@ class IdentificationFieldTest extends TestCase
      * @param string $headerString
      * @param string[] $ids
      */
-    public function testSetEncodingHasNoEffect($className, $headerString, array $ids)
+    public function testSetEncodingHasNoEffect($className, $headerString, array $ids): void
     {
         /** @var IdentificationField $header */
         $header = $className::fromString($headerString);
@@ -111,7 +111,7 @@ class IdentificationFieldTest extends TestCase
      * @param string $className
      * @param string[] $ids
      */
-    public function testSetIdsThrowsOnInvalidInput($className, $ids)
+    public function testSetIdsThrowsOnInvalidInput($className, $ids): void
     {
         /** @var IdentificationField $header */
         $header = new $className();
@@ -125,7 +125,7 @@ class IdentificationFieldTest extends TestCase
      * @param string $className
      * @param string[] $ids
      */
-    public function testFromStringRaisesExceptionOnInvalidHeader($className, $ids)
+    public function testFromStringRaisesExceptionOnInvalidHeader($className, $ids): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line');

--- a/test/Header/IdentificationFieldTest.php
+++ b/test/Header/IdentificationFieldTest.php
@@ -23,8 +23,8 @@ class IdentificationFieldTest extends TestCase
                 [
                     References::class,
                     'References: <1234@local.machine.example> <3456@example.net>',
-                    ['1234@local.machine.example', '3456@example.net']
-                ]
+                    ['1234@local.machine.example', '3456@example.net'],
+                ],
             ],
             $this->reversibleStringHeadersProvider()
         );
@@ -37,9 +37,9 @@ class IdentificationFieldTest extends TestCase
             [
                 References::class,
                 "References: <1234@local.machine.example>\r\n <3456@example.net>",
-                ['1234@local.machine.example', '3456@example.net']
+                ['1234@local.machine.example', '3456@example.net'],
             ],
-            [InReplyTo::class, 'In-Reply-To: <3456@example.net>', ['3456@example.net']]
+            [InReplyTo::class, 'In-Reply-To: <3456@example.net>', ['3456@example.net']],
         ];
     }
 

--- a/test/Header/MessageIdTest.php
+++ b/test/Header/MessageIdTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MessageIdTest extends TestCase
 {
-    public function testSettingManually()
+    public function testSettingManually(): void
     {
         $id = "CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com";
         $messageid = new Header\MessageId();
@@ -30,7 +30,7 @@ class MessageIdTest extends TestCase
         $this->assertEquals("Message-ID: $expected", $messageid->toString());
     }
 
-    public function testAutoGeneration()
+    public function testAutoGeneration(): void
     {
         $messageid = new Header\MessageId();
         $messageid->setId();
@@ -38,7 +38,7 @@ class MessageIdTest extends TestCase
         $this->assertContains('@', $messageid->getFieldValue());
     }
 
-    public function testAutoGenerationWithServerVars()
+    public function testAutoGenerationWithServerVars(): void
     {
         $serverBeforeTest = $_SERVER;
         $_SERVER['REMOTE_ADDR'] = '172.16.0.1';
@@ -50,7 +50,7 @@ class MessageIdTest extends TestCase
         $_SERVER = $serverBeforeTest;
     }
 
-    public function headerLines()
+    public function headerLines(): array
     {
         return [
             'newline'      => ["Message-ID: foo\nbar"],
@@ -64,13 +64,13 @@ class MessageIdTest extends TestCase
      * @dataProvider headerLines
      * @group ZF2015-04
      */
-    public function testFromStringPreventsCrlfInjectionOnDetection($header)
+    public function testFromStringPreventsCrlfInjectionOnDetection($header): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $messageid = Header\MessageId::fromString($header);
     }
 
-    public function invalidIdentifiers()
+    public function invalidIdentifiers(): array
     {
         return [
             'newline'      => ["foo\nbar"],
@@ -85,27 +85,27 @@ class MessageIdTest extends TestCase
      * @dataProvider invalidIdentifiers
      * @group ZF2015-04
      */
-    public function testInvalidIdentifierRaisesException($id)
+    public function testInvalidIdentifierRaisesException($id): void
     {
         $header = new Header\MessageId();
         $this->expectException(Exception\InvalidArgumentException::class);
         $header->setId($id);
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for Message-ID string');
         Header\MessageId::fromString('Foo: bar');
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new Header\MessageId();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncodingHasNoEffect()
+    public function testSetEncodingHasNoEffect(): void
     {
         $header = new Header\MessageId();
         $header->setEncoding('UTF-8');

--- a/test/Header/MimeVersionTest.php
+++ b/test/Header/MimeVersionTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MimeVersionTest extends TestCase
 {
-    public function testSettingManually()
+    public function testSettingManually(): void
     {
         $version = "2.0";
         $mime = new Header\MimeVersion();
@@ -26,14 +26,14 @@ class MimeVersionTest extends TestCase
         $this->assertEquals($version, $mime->getFieldValue());
     }
 
-    public function testDefaultVersion()
+    public function testDefaultVersion(): void
     {
         $mime = new Header\MimeVersion();
         $this->assertEquals('1.0', $mime->getVersion());
         $this->assertEquals('MIME-Version: 1.0', $mime->toString());
     }
 
-    public function headerLines()
+    public function headerLines(): array
     {
         return [
             'newline'      => ["MIME-Version: 5.0\nbar"],
@@ -47,13 +47,13 @@ class MimeVersionTest extends TestCase
      * @dataProvider headerLines
      * @group ZF2015-04
      */
-    public function testFromStringRaisesExceptionOnDetectionOfCrlfInjection($header)
+    public function testFromStringRaisesExceptionOnDetectionOfCrlfInjection($header): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $mime = Header\MimeVersion::fromString($header);
     }
 
-    public function invalidVersions()
+    public function invalidVersions(): array
     {
         return [
             'no-decimal'    => ['1'],
@@ -67,27 +67,27 @@ class MimeVersionTest extends TestCase
      * @dataProvider invalidVersions
      * @group ZF2015-04
      */
-    public function testRaisesExceptionOnInvalidVersionFromSetVersion($value)
+    public function testRaisesExceptionOnInvalidVersionFromSetVersion($value): void
     {
         $header = new Header\MimeVersion();
         $this->expectException(Exception\InvalidArgumentException::class);
         $header->setVersion($value);
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for MIME-Version string');
         Header\MimeVersion::fromString('Foo: bar');
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new Header\MimeVersion();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncodingHasNoEffect()
+    public function testSetEncodingHasNoEffect(): void
     {
         $header = new Header\MimeVersion();
         $header->setEncoding('UTF-8');

--- a/test/Header/MimeVersionTest.php
+++ b/test/Header/MimeVersionTest.php
@@ -83,13 +83,13 @@ class MimeVersionTest extends TestCase
 
     public function testDefaultEncoding()
     {
-        $header = new Header\MimeVersion('1.0');
+        $header = new Header\MimeVersion();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
     public function testSetEncodingHasNoEffect()
     {
-        $header = new Header\MimeVersion('1.0');
+        $header = new Header\MimeVersion();
         $header->setEncoding('UTF-8');
         $this->assertSame('ASCII', $header->getEncoding());
     }

--- a/test/Header/ReceivedTest.php
+++ b/test/Header/ReceivedTest.php
@@ -20,20 +20,20 @@ use PHPUnit\Framework\TestCase;
  */
 class ReceivedTest extends TestCase
 {
-    public function testFromStringCreatesValidReceivedHeader()
+    public function testFromStringCreatesValidReceivedHeader(): void
     {
         $receivedHeader = Header\Received::fromString('Received: xxx');
         $this->assertInstanceOf(HeaderInterface::class, $receivedHeader);
         $this->assertInstanceOf(Received::class, $receivedHeader);
     }
 
-    public function testGetFieldNameReturnsHeaderName()
+    public function testGetFieldNameReturnsHeaderName(): void
     {
         $receivedHeader = new Header\Received();
         $this->assertEquals('Received', $receivedHeader->getFieldName());
     }
 
-    public function testReceivedGetFieldValueReturnsProperValue()
+    public function testReceivedGetFieldValueReturnsProperValue(): void
     {
         $this->markTestIncomplete('Received needs to be completed');
 
@@ -41,7 +41,7 @@ class ReceivedTest extends TestCase
         $this->assertEquals('xxx', $receivedHeader->getFieldValue());
     }
 
-    public function testReceivedToStringReturnsHeaderFormattedString()
+    public function testReceivedToStringReturnsHeaderFormattedString(): void
     {
         $this->markTestIncomplete('Received needs to be completed');
 
@@ -53,7 +53,7 @@ class ReceivedTest extends TestCase
 
     /** Implementation specific tests here */
 
-    public function headerLines()
+    public function headerLines(): array
     {
         return [
             'newline'      => ["Received: xx\nx"],
@@ -68,13 +68,13 @@ class ReceivedTest extends TestCase
      * @dataProvider headerLines
      * @group ZF2015-04
      */
-    public function testRaisesExceptionViaFromStringOnDetectionOfCrlfInjection($header)
+    public function testRaisesExceptionViaFromStringOnDetectionOfCrlfInjection($header): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $received = Header\Received::fromString($header);
     }
 
-    public function invalidValues()
+    public function invalidValues(): array
     {
         return [
             'newline'      => ["xx\nx"],
@@ -88,39 +88,39 @@ class ReceivedTest extends TestCase
      * @dataProvider invalidValues
      * @group ZF2015-04
      */
-    public function testConstructorRaisesExceptionOnValueWithCRLFInjectionAttempt($value)
+    public function testConstructorRaisesExceptionOnValueWithCRLFInjectionAttempt($value): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Header\Received($value);
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for Received string');
         Header\Received::fromString('Foo: bar');
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = Header\Received::fromString('Received: test');
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncodingHasNoEffect()
+    public function testSetEncodingHasNoEffect(): void
     {
         $header = Header\Received::fromString('Received: test');
         $header->setEncoding('UTF-8');
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $header = new Header\Received('test');
         $this->assertEquals('Received: test', $header->toString());
     }
 
-    public function testToStringMultipleHeaders()
+    public function testToStringMultipleHeaders(): void
     {
         $header = new Header\Received('test');
         $this->assertEquals('Received: test', $header->toStringMultipleHeaders([]));
@@ -138,7 +138,7 @@ class ReceivedTest extends TestCase
         );
     }
 
-    public function testToStringMultipleHeadersThrows()
+    public function testToStringMultipleHeadersThrows(): void
     {
         $header = new Header\Received('test');
         $this->expectException(Exception\RuntimeException::class);

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -271,13 +271,13 @@ class SenderTest extends TestCase
 
     public function testDefaultEncoding()
     {
-        $header = new Header\Sender('<test@example.com>');
+        $header = new Header\Sender();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
     public function testSetEncoding()
     {
-        $header = new Header\Sender('<test@example.com>');
+        $header = new Header\Sender();
         $header->setEncoding('UTF-8');
         $this->assertSame('UTF-8', $header->getEncoding());
     }

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -128,21 +128,21 @@ class SenderTest extends TestCase
                 null,
                 '<foo@bar>',
                 '<foo@bar>',
-                'ASCII'
+                'ASCII',
             ],
             'ASCII name' => [
                 'foo@bar',
                 'foo',
                 'foo <foo@bar>',
                 'foo <foo@bar>',
-                'ASCII'
+                'ASCII',
             ],
             'UTF-8 name' => [
                 'foo@bar',
                 'ázÁZ09',
                 'ázÁZ09 <foo@bar>',
                 '=?UTF-8?Q?=C3=A1z=C3=81Z09?= <foo@bar>',
-                'UTF-8'
+                'UTF-8',
             ],
         ];
     }
@@ -156,8 +156,8 @@ class SenderTest extends TestCase
             'Unbracketed email' => [
                 '<foo@bar>',
                 'foo@bar',
-                'ASCII'
-            ]
+                'ASCII',
+            ],
         ]);
     }
 

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -21,14 +21,14 @@ use PHPUnit\Framework\TestCase;
  */
 class SenderTest extends TestCase
 {
-    public function testFromStringCreatesValidReceivedHeader()
+    public function testFromStringCreatesValidReceivedHeader(): void
     {
         $sender = Header\Sender::fromString('Sender: <foo@bar>');
         $this->assertInstanceOf(HeaderInterface::class, $sender);
         $this->assertInstanceOf(Sender::class, $sender);
     }
 
-    public function testGetFieldNameReturnsHeaderName()
+    public function testGetFieldNameReturnsHeaderName(): void
     {
         $sender = new Header\Sender();
         $this->assertEquals('Sender', $sender->getFieldName());
@@ -43,7 +43,7 @@ class SenderTest extends TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testParseValidSenderHeader($expectedFieldValue, $encodedValue, $encoding)
+    public function testParseValidSenderHeader($expectedFieldValue, $encodedValue, $encoding): void
     {
         $header = Header\Sender::fromString('Sender:' . $encodedValue);
 
@@ -60,7 +60,7 @@ class SenderTest extends TestCase
     public function testParseInvalidSenderHeaderThrowException(
         $decodedValue,
         $expectedException
-    ) {
+    ): void {
         $this->expectException($expectedException);
         Header\Sender::fromString('Sender:' . $decodedValue);
     }
@@ -74,7 +74,7 @@ class SenderTest extends TestCase
      * @param string $expectedFieldValue,
      * @param string $encoding
      */
-    public function testSetAddressValidValue($email, $name, $expectedFieldValue, $encodedValue, $encoding)
+    public function testSetAddressValidValue($email, $name, $expectedFieldValue, $encodedValue, $encoding): void
     {
         $header = new Header\Sender();
         $header->setAddress($email, $name);
@@ -90,7 +90,7 @@ class SenderTest extends TestCase
      * @param string $email
      * @param null|string $name
      */
-    public function testSetAddressInvalidValue($email, $name)
+    public function testSetAddressInvalidValue($email, $name): void
     {
         $header = new Header\Sender();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -106,7 +106,7 @@ class SenderTest extends TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testSetAddressValidAddressObject($email, $name, $expectedFieldValue, $encodedValue, $encoding)
+    public function testSetAddressValidAddressObject($email, $name, $expectedFieldValue, $encodedValue, $encoding): void
     {
         $address = new Address($email, $name);
 
@@ -119,7 +119,7 @@ class SenderTest extends TestCase
         $this->assertEquals($encoding, $header->getEncoding());
     }
 
-    public function validSenderDataProvider()
+    public function validSenderDataProvider(): array
     {
         return [
             // Description => [sender address, sender name, getFieldValue, encoded version, encoding],
@@ -147,7 +147,7 @@ class SenderTest extends TestCase
         ];
     }
 
-    public function validSenderHeaderDataProvider()
+    public function validSenderHeaderDataProvider(): array
     {
         return array_merge(array_map(function ($parameters) {
             return array_slice($parameters, 2);
@@ -161,7 +161,7 @@ class SenderTest extends TestCase
         ]);
     }
 
-    public function invalidSenderDataProvider()
+    public function invalidSenderDataProvider(): array
     {
         $mailInvalidArgumentException = Exception\InvalidArgumentException::class;
 
@@ -184,7 +184,7 @@ class SenderTest extends TestCase
         ];
     }
 
-    public function invalidSenderEncodedDataProvider()
+    public function invalidSenderEncodedDataProvider(): array
     {
         $mailInvalidArgumentException = Exception\InvalidArgumentException::class;
         $headerInvalidArgumentException = Header\Exception\InvalidArgumentException::class;
@@ -215,7 +215,7 @@ class SenderTest extends TestCase
      *
      * @dataProvider validHeaderLinesProvider
      */
-    public function testFromStringWithValidInput($headerString, $expectedName, $expectedEmail)
+    public function testFromStringWithValidInput($headerString, $expectedName, $expectedEmail): void
     {
         $header = Header\Sender::fromString($headerString);
 
@@ -223,7 +223,7 @@ class SenderTest extends TestCase
         $this->assertSame($expectedEmail, $header->getAddress()->getEmail());
     }
 
-    public function validHeaderLinesProvider()
+    public function validHeaderLinesProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -246,7 +246,7 @@ class SenderTest extends TestCase
      *
      * @dataProvider invalidHeaderLinesProvider
      */
-    public function testFromStringWithInvalidInput($headerString, $expectedException, $expectedMessagePart = '')
+    public function testFromStringWithInvalidInput($headerString, $expectedException, $expectedMessagePart = ''): void
     {
         $this->expectException($expectedException);
         if ($expectedMessagePart) {
@@ -256,7 +256,7 @@ class SenderTest extends TestCase
         Header\Sender::fromString($headerString);
     }
 
-    public function invalidHeaderLinesProvider()
+    public function invalidHeaderLinesProvider(): array
     {
         $mailInvalidArgumentException = Exception\InvalidArgumentException::class;
         $headerInvalidArgumentException = Header\Exception\InvalidArgumentException::class;
@@ -269,20 +269,20 @@ class SenderTest extends TestCase
         ];
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = new Header\Sender();
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncoding()
+    public function testSetEncoding(): void
     {
         $header = new Header\Sender();
         $header->setEncoding('UTF-8');
         $this->assertSame('UTF-8', $header->getEncoding());
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header name for Sender string');

--- a/test/Header/SubjectTest.php
+++ b/test/Header/SubjectTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SubjectTest extends TestCase
 {
-    public function testHeaderFolding()
+    public function testHeaderFolding(): void
     {
         $string  = str_repeat('foobarblahblahblah baz bat', 10);
         $subject = new Header\Subject();
@@ -29,13 +29,13 @@ class SubjectTest extends TestCase
         $this->assertEquals($expected, $test);
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $header = Header\Subject::fromString('Subject: test');
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function testSetEncoding()
+    public function testSetEncoding(): void
     {
         $header = Header\Subject::fromString('Subject: test');
         $header->setEncoding('UTF-8');
@@ -49,7 +49,7 @@ class SubjectTest extends TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testParseValidSubjectHeader($decodedValue, $encodedValue, $encoding)
+    public function testParseValidSubjectHeader($decodedValue, $encodedValue, $encoding): void
     {
         $header = Header\Subject::fromString('Subject:' . $encodedValue);
 
@@ -68,13 +68,13 @@ class SubjectTest extends TestCase
         $decodedValue,
         $expectedException,
         $expectedExceptionMessage
-    ) {
+    ): void {
         $this->expectException($expectedException);
         $this->expectExceptionMessage($expectedExceptionMessage);
         Header\Subject::fromString('Subject:' . $decodedValue);
     }
 
-    public function testFromStringRaisesExceptionOnInvalidHeader()
+    public function testFromStringRaisesExceptionOnInvalidHeader(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header line for Subject string');
@@ -88,7 +88,7 @@ class SubjectTest extends TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testSetSubjectValidValue($decodedValue, $encodedValue, $encoding)
+    public function testSetSubjectValidValue($decodedValue, $encodedValue, $encoding): void
     {
         $header = new Header\Subject();
         $header->setSubject($decodedValue);
@@ -98,7 +98,7 @@ class SubjectTest extends TestCase
         $this->assertEquals($encoding, $header->getEncoding());
     }
 
-    public function validSubjectValuesProvider()
+    public function validSubjectValuesProvider(): array
     {
         return [
             // Description => [decoded format, encoded format, encoding],
@@ -116,7 +116,7 @@ class SubjectTest extends TestCase
         ];
     }
 
-    public function invalidSubjectValuesProvider()
+    public function invalidSubjectValuesProvider(): array
     {
         $invalidArgumentException = Exception\InvalidArgumentException::class;
         $invalidHeaderValueDetected = 'Invalid header value detected';
@@ -130,7 +130,7 @@ class SubjectTest extends TestCase
         ];
     }
 
-    public function testChangeEncodingToAsciiNotAllowedWhenSubjectContainsUtf8Characters()
+    public function testChangeEncodingToAsciiNotAllowedWhenSubjectContainsUtf8Characters(): void
     {
         $subject = new Header\Subject();
         $subject->setSubject('Accents òàùèéì');
@@ -141,7 +141,7 @@ class SubjectTest extends TestCase
         self::assertSame('UTF-8', $subject->getEncoding());
     }
 
-    public function testChangeEncodingBackToAscii()
+    public function testChangeEncodingBackToAscii(): void
     {
         $subject = new Header\Subject();
         $subject->setSubject('test');
@@ -155,7 +155,7 @@ class SubjectTest extends TestCase
         self::assertSame('ASCII', $subject->getEncoding());
     }
 
-    public function testSetNullEncoding()
+    public function testSetNullEncoding(): void
     {
         $subject = Header\Subject::fromString('Subject: test');
         self::assertSame('ASCII', $subject->getEncoding());
@@ -164,7 +164,7 @@ class SubjectTest extends TestCase
         self::assertSame('ASCII', $subject->getEncoding());
     }
 
-    public function testSettingSubjectCanChangeEncoding()
+    public function testSettingSubjectCanChangeEncoding(): void
     {
         $subject = Header\Subject::fromString('Subject: test');
         self::assertSame('ASCII', $subject->getEncoding());
@@ -173,7 +173,7 @@ class SubjectTest extends TestCase
         self::assertSame('UTF-8', $subject->getEncoding());
     }
 
-    public function testSettingTheSameEncoding()
+    public function testSettingTheSameEncoding(): void
     {
         $subject = Header\Subject::fromString('Subject: test');
         self::assertSame('ASCII', $subject->getEncoding());

--- a/test/Header/ToTest.php
+++ b/test/Header/ToTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ToTest extends TestCase
 {
-    public function testHeaderFoldingOccursProperly()
+    public function testHeaderFoldingOccursProperly(): void
     {
         $header = new Header\To();
         $list   = $header->getAddressList();
@@ -33,7 +33,7 @@ class ToTest extends TestCase
         $this->assertEquals(10, count($emails));
     }
 
-    public function headerLines()
+    public function headerLines(): array
     {
         return [
             'newline'      => ["To: xxx yyy\n"],
@@ -47,7 +47,7 @@ class ToTest extends TestCase
      * @dataProvider headerLines
      * @group ZF2015-04
      */
-    public function testFromStringRaisesExceptionWhenCrlfInjectionIsDetected($header)
+    public function testFromStringRaisesExceptionWhenCrlfInjectionIsDetected($header): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         Header\To::fromString($header);

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -42,7 +42,7 @@ class HeadersTest extends TestCase
     public function setDeprecationErrorHandler(): void
     {
         $this->originalErrorHandler = set_error_handler(
-            function (int $errno, string $errstr, string $errfile, int $errline) {
+            function (int $errno, string $errstr, string $errfile, int $errline): void {
                 throw new Deprecated($errstr, $errno, $errfile, $errline);
             },
             E_USER_DEPRECATED
@@ -59,14 +59,14 @@ class HeadersTest extends TestCase
         $this->originalErrorHandler = null;
     }
 
-    public function testHeadersImplementsProperClasses()
+    public function testHeadersImplementsProperClasses(): void
     {
         $headers = new Mail\Headers();
         $this->assertInstanceOf(\Iterator::class, $headers);
         $this->assertInstanceOf(\Countable::class, $headers);
     }
 
-    public function testHeadersFromStringFactoryCreatesSingleObject()
+    public function testHeadersFromStringFactoryCreatesSingleObject(): void
     {
         $headers = Mail\Headers::fromString("Fake: foo-bar");
         $this->assertEquals(1, $headers->count());
@@ -77,7 +77,7 @@ class HeadersTest extends TestCase
         $this->assertEquals('foo-bar', $header->getFieldValue());
     }
 
-    public function testHeadersFromStringFactoryHandlesMissingWhitespace()
+    public function testHeadersFromStringFactoryHandlesMissingWhitespace(): void
     {
         $headers = Mail\Headers::fromString("Fake:foo-bar");
         $this->assertEquals(1, $headers->count());
@@ -91,7 +91,7 @@ class HeadersTest extends TestCase
     /**
      * @group 6657
      */
-    public function testHeadersFromStringFactoryCreatesSingleObjectWithContinuationLine()
+    public function testHeadersFromStringFactoryCreatesSingleObjectWithContinuationLine(): void
     {
         $headers = Mail\Headers::fromString("Fake: foo-bar,\r\n      blah-blah");
         $this->assertEquals(1, $headers->count());
@@ -102,7 +102,7 @@ class HeadersTest extends TestCase
         $this->assertEquals('foo-bar, blah-blah', $header->getFieldValue());
     }
 
-    public function testHeadersFromStringFactoryCreatesSingleObjectWithHeaderBreakLine()
+    public function testHeadersFromStringFactoryCreatesSingleObjectWithHeaderBreakLine(): void
     {
         $headers = Mail\Headers::fromString("Fake: foo-bar\r\n\r\n");
         $this->assertEquals(1, $headers->count());
@@ -113,21 +113,21 @@ class HeadersTest extends TestCase
         $this->assertEquals('foo-bar', $header->getFieldValue());
     }
 
-    public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLine()
+    public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLine(): void
     {
         $this->expectException(Mail\Exception\RuntimeException::class);
         $this->expectExceptionMessage('does not match');
         Mail\Headers::fromString("Fake = foo-bar\r\n\r\n");
     }
 
-    public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLines()
+    public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLines(): void
     {
         $this->expectException(Mail\Exception\RuntimeException::class);
         $this->expectExceptionMessage('Malformed header detected');
         Mail\Headers::fromString("Fake: foo-bar\r\n\r\n\r\n\r\nAnother-Fake: boo-baz");
     }
 
-    public function testHeadersFromStringFactoryCreatesMultipleObjects()
+    public function testHeadersFromStringFactoryCreatesMultipleObjects(): void
     {
         $headers = Mail\Headers::fromString("Fake: foo-bar\r\nAnother-Fake: boo-baz");
         $this->assertEquals(2, $headers->count());
@@ -143,7 +143,7 @@ class HeadersTest extends TestCase
         $this->assertEquals('boo-baz', $header->getFieldValue());
     }
 
-    public function testHeadersFromStringMultiHeaderWillAggregateLazyLoadedHeaders()
+    public function testHeadersFromStringMultiHeaderWillAggregateLazyLoadedHeaders(): void
     {
         $headers = new Mail\Headers();
         $loader  = $headers->getHeaderLocator();
@@ -153,7 +153,7 @@ class HeadersTest extends TestCase
         $this->assertEquals(3, $headers->count());
     }
 
-    public function testHeadersHasAndGetWorkProperly()
+    public function testHeadersHasAndGetWorkProperly(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders([
@@ -166,7 +166,7 @@ class HeadersTest extends TestCase
         $this->assertEquals('bar', $headers->get('foo')->getFieldValue());
     }
 
-    public function testHeadersAggregatesHeaderObjects()
+    public function testHeadersAggregatesHeaderObjects(): void
     {
         $fakeHeader = new Header\GenericHeader('Fake', 'bar');
         $headers = new Mail\Headers();
@@ -175,7 +175,7 @@ class HeadersTest extends TestCase
         $this->assertEquals('bar', $headers->get('Fake')->getFieldValue());
     }
 
-    public function testHeadersAggregatesHeaderThroughAddHeader()
+    public function testHeadersAggregatesHeaderThroughAddHeader(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeader(new Header\GenericHeader('Fake', 'bar'));
@@ -183,7 +183,7 @@ class HeadersTest extends TestCase
         $this->assertInstanceOf(GenericHeader::class, $headers->get('Fake'));
     }
 
-    public function testHeadersAggregatesHeaderThroughAddHeaderLine()
+    public function testHeadersAggregatesHeaderThroughAddHeaderLine(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaderLine('Fake', 'bar');
@@ -191,7 +191,7 @@ class HeadersTest extends TestCase
         $this->assertInstanceOf(GenericHeader::class, $headers->get('Fake'));
     }
 
-    public function testHeadersAddHeaderLineThrowsExceptionOnMissingFieldValue()
+    public function testHeadersAddHeaderLineThrowsExceptionOnMissingFieldValue(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Header must match with the format "name:value"');
@@ -199,7 +199,7 @@ class HeadersTest extends TestCase
         $headers->addHeaderLine('Foo');
     }
 
-    public function testHeadersAddHeaderLineThrowsExceptionOnInvalidFieldNull()
+    public function testHeadersAddHeaderLineThrowsExceptionOnInvalidFieldNull(): void
     {
         $headers = new Mail\Headers();
 
@@ -208,7 +208,7 @@ class HeadersTest extends TestCase
         $headers->addHeaderLine(null);
     }
 
-    public function testHeadersAddHeaderLineThrowsExceptionOnInvalidFieldObject()
+    public function testHeadersAddHeaderLineThrowsExceptionOnInvalidFieldObject(): void
     {
         $headers = new Mail\Headers();
         $object = new \stdClass();
@@ -218,7 +218,7 @@ class HeadersTest extends TestCase
         $headers->addHeaderLine($object);
     }
 
-    public function testHeadersAggregatesHeadersThroughAddHeaders()
+    public function testHeadersAggregatesHeadersThroughAddHeaders(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders([new Header\GenericHeader('Foo', 'bar'), new Header\GenericHeader('Baz', 'baz')]);
@@ -256,7 +256,7 @@ class HeadersTest extends TestCase
         $this->assertEquals('baz', $headers->get('baz')->getFieldValue());
     }
 
-    public function testHeadersAddHeadersThrowsExceptionOnInvalidArguments()
+    public function testHeadersAddHeadersThrowsExceptionOnInvalidArguments(): void
     {
         $this->expectException(Mail\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected array or Traversable');
@@ -264,7 +264,7 @@ class HeadersTest extends TestCase
         $headers->addHeaders('foo');
     }
 
-    public function testHeadersCanRemoveHeader()
+    public function testHeadersCanRemoveHeader(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders(['Foo' => 'bar', 'Baz' => 'baz']);
@@ -275,7 +275,7 @@ class HeadersTest extends TestCase
         $this->assertTrue($headers->has('baz'));
     }
 
-    public function testRemoveHeaderWithFieldNameWillRemoveAllInstances()
+    public function testRemoveHeaderWithFieldNameWillRemoveAllInstances(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders([['Foo' => 'foo'], ['Foo' => 'bar'], 'Baz' => 'baz']);
@@ -286,7 +286,7 @@ class HeadersTest extends TestCase
         $this->assertTrue($headers->has('baz'));
     }
 
-    public function testRemoveHeaderWithInstanceWillRemoveThatInstance()
+    public function testRemoveHeaderWithInstanceWillRemoveThatInstance(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders([['Foo' => 'foo'], ['Foo' => 'bar'], 'Baz' => 'baz']);
@@ -298,13 +298,13 @@ class HeadersTest extends TestCase
         $this->assertNotSame($header, $headers->get('foo'));
     }
 
-    public function testRemoveHeaderWhenEmpty()
+    public function testRemoveHeaderWhenEmpty(): void
     {
         $headers = new Mail\Headers();
         $this->assertFalse($headers->removeHeader(''));
     }
 
-    public function testHeadersCanClearAllHeaders()
+    public function testHeadersCanClearAllHeaders(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders(['Foo' => 'bar', 'Baz' => 'baz']);
@@ -313,7 +313,7 @@ class HeadersTest extends TestCase
         $this->assertEquals(0, $headers->count());
     }
 
-    public function testHeadersCanBeIterated()
+    public function testHeadersCanBeIterated(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders(['Foo' => 'bar', 'Baz' => 'baz']);
@@ -335,21 +335,21 @@ class HeadersTest extends TestCase
         $this->assertEquals(2, $iterations);
     }
 
-    public function testHeadersCanBeCastToString()
+    public function testHeadersCanBeCastToString(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders(['Foo' => 'bar', 'Baz' => 'baz']);
         $this->assertEquals('Foo: bar' . "\r\n" . 'Baz: baz' . "\r\n", $headers->toString());
     }
 
-    public function testHeadersCanBeCastToArray()
+    public function testHeadersCanBeCastToArray(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaders(['Foo' => 'bar', 'Baz' => 'baz']);
         $this->assertEquals(['Foo' => 'bar', 'Baz' => 'baz'], $headers->toArray());
     }
 
-    public function testCastingToArrayReturnsMultiHeadersAsArrays()
+    public function testCastingToArrayReturnsMultiHeadersAsArrays(): void
     {
         $headers = new Mail\Headers();
 
@@ -370,7 +370,7 @@ class HeadersTest extends TestCase
         $this->assertEquals($expected, $array);
     }
 
-    public function testCastingToStringReturnsAllMultiHeaderValues()
+    public function testCastingToStringReturnsAllMultiHeaderValues(): void
     {
         $headers = new Mail\Headers();
 
@@ -390,7 +390,7 @@ class HeadersTest extends TestCase
         $this->assertEquals($expected, $string);
     }
 
-    public function testGetReturnsArrayIterator()
+    public function testGetReturnsArrayIterator(): void
     {
         $headers = new Mail\Headers();
         $received = Header\Received::fromString('Received: from framework (localhost [127.0.0.1])');
@@ -401,10 +401,10 @@ class HeadersTest extends TestCase
     }
 
     /**
-     * @test that toArray can take format parameter
+     * Test that toArray can take format parameter
      * @see https://github.com/zendframework/zend-mail/pull/61
      */
-    public function testToArrayFormatRaw()
+    public function testToArrayFormatRaw(): void
     {
         $raw_subject = '=?ISO-8859-2?Q?PD=3A_My=3A_Go=B3?= =?ISO-8859-2?Q?blahblah?=';
         $headers = new Mail\Headers();
@@ -419,10 +419,10 @@ class HeadersTest extends TestCase
     }
 
     /**
-     * @test that toArray can take format parameter
+     * Test that toArray can take format parameter
      * @see https://github.com/zendframework/zend-mail/pull/61
      */
-    public function testToArrayFormatEncoded()
+    public function testToArrayFormatEncoded(): void
     {
         $raw_subject = '=?ISO-8859-2?Q?PD=3A_My=3A_Go=B3?= =?ISO-8859-2?Q?blahblah?=';
         $headers = new Mail\Headers();
@@ -437,7 +437,7 @@ class HeadersTest extends TestCase
         $this->assertEquals($expected, $array);
     }
 
-    public function testClone()
+    public function testClone(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeader(new Header\Bcc());
@@ -451,7 +451,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackFromString()
+    public function testHeaderCrLfAttackFromString(): void
     {
         $this->expectException(Mail\Exception\RuntimeException::class);
         Mail\Headers::fromString("Fake: foo-bar\r\n\r\nevilContent");
@@ -460,7 +460,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackAddHeaderLineSingle()
+    public function testHeaderCrLfAttackAddHeaderLineSingle(): void
     {
         $headers = new Mail\Headers();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -470,7 +470,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackAddHeaderLineWithValue()
+    public function testHeaderCrLfAttackAddHeaderLineWithValue(): void
     {
         $headers = new Mail\Headers();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -480,7 +480,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackAddHeaderLineMultiple()
+    public function testHeaderCrLfAttackAddHeaderLineMultiple(): void
     {
         $headers = new Mail\Headers();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -491,7 +491,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackAddHeadersSingle()
+    public function testHeaderCrLfAttackAddHeadersSingle(): void
     {
         $headers = new Mail\Headers();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -501,7 +501,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackAddHeadersWithValue()
+    public function testHeaderCrLfAttackAddHeadersWithValue(): void
     {
         $headers = new Mail\Headers();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -511,7 +511,7 @@ class HeadersTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testHeaderCrLfAttackAddHeadersMultiple()
+    public function testHeaderCrLfAttackAddHeadersMultiple(): void
     {
         $headers = new Mail\Headers();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -519,7 +519,7 @@ class HeadersTest extends TestCase
         $headers->forceLoading();
     }
 
-    public function testAddressListGetEncodedFieldValueWithUtf8Domain()
+    public function testAddressListGetEncodedFieldValueWithUtf8Domain(): void
     {
         $to = new Header\To();
         $to->setEncoding('UTF-8');
@@ -545,7 +545,7 @@ class HeadersTest extends TestCase
      *
      * @see https://github.com/zendframework/zend-mail/issues/127
      */
-    public function testEmailNameParser()
+    public function testEmailNameParser(): void
     {
         $to = Header\To::fromString('To: "=?UTF-8?Q?=C3=B5lu?= <bar" <foo.bar@test.com>');
 
@@ -561,20 +561,20 @@ class HeadersTest extends TestCase
         $this->assertEquals('õlu <bar <foo.bar@test.com>', $encodedValue);
     }
 
-    public function testDefaultEncoding()
+    public function testDefaultEncoding(): void
     {
         $headers = new Mail\Headers();
         $this->assertSame('ASCII', $headers->getEncoding());
     }
 
-    public function testSetEncodingNoHeaders()
+    public function testSetEncodingNoHeaders(): void
     {
         $headers = new Mail\Headers();
         $headers->setEncoding('UTF-8');
         $this->assertSame('UTF-8', $headers->getEncoding());
     }
 
-    public function testSetEncodingWithHeaders()
+    public function testSetEncodingWithHeaders(): void
     {
         $headers = new Mail\Headers();
         $headers->addHeaderLine('To: test@example.com');
@@ -584,7 +584,7 @@ class HeadersTest extends TestCase
         $this->assertSame('UTF-8', $headers->getEncoding());
     }
 
-    public function testAddHeaderCallsSetEncoding()
+    public function testAddHeaderCallsSetEncoding(): void
     {
         $headers = new Mail\Headers();
         $headers->setEncoding('UTF-8');
@@ -601,7 +601,7 @@ class HeadersTest extends TestCase
     /**
      * @todo Remove for 3.0.0
      */
-    public function testGetPluginClassLoaderEmitsDeprecationNotice()
+    public function testGetPluginClassLoaderEmitsDeprecationNotice(): void
     {
         $this->setDeprecationErrorHandler();
         $headers = new Mail\Headers();
@@ -614,7 +614,7 @@ class HeadersTest extends TestCase
     /**
      * @todo Remove for 3.0.0
      */
-    public function testSetPluginClassLoaderEmitsDeprecationNotice()
+    public function testSetPluginClassLoaderEmitsDeprecationNotice(): void
     {
         $this->setDeprecationErrorHandler();
         $headers = new Mail\Headers();
@@ -625,14 +625,14 @@ class HeadersTest extends TestCase
         $headers->setPluginClassLoader($loader);
     }
 
-    public function testGetHeaderLocatorReturnsHeaderLocatorInstanceByDefault()
+    public function testGetHeaderLocatorReturnsHeaderLocatorInstanceByDefault(): void
     {
         $headers = new Mail\Headers();
         $locator = $headers->getHeaderLocator();
         $this->assertInstanceOf(Mail\Header\HeaderLocator::class, $locator);
     }
 
-    public function testCanInjectAlternateHeaderLocatorInstance()
+    public function testCanInjectAlternateHeaderLocatorInstance(): void
     {
         $headers = new Mail\Headers();
         $locator = $this->prophesize(Mail\Header\HeaderLocatorInterface::class)->reveal();

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -402,7 +402,7 @@ class HeadersTest extends TestCase
 
     /**
      * @test that toArray can take format parameter
-     * @link https://github.com/zendframework/zend-mail/pull/61
+     * @see https://github.com/zendframework/zend-mail/pull/61
      */
     public function testToArrayFormatRaw()
     {
@@ -420,7 +420,7 @@ class HeadersTest extends TestCase
 
     /**
      * @test that toArray can take format parameter
-     * @link https://github.com/zendframework/zend-mail/pull/61
+     * @see https://github.com/zendframework/zend-mail/pull/61
      */
     public function testToArrayFormatEncoded()
     {

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -521,7 +521,7 @@ class HeadersTest extends TestCase
 
     public function testAddressListGetEncodedFieldValueWithUtf8Domain()
     {
-        $to = new Header\To;
+        $to = new Header\To();
         $to->setEncoding('UTF-8');
         $to->getAddressList()->add('local-part@ä-umlaut.de');
         $encodedValue = $to->getFieldValue(Header\HeaderInterface::FORMAT_ENCODED);

--- a/test/MessageFactoryTest.php
+++ b/test/MessageFactoryTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MessageFactoryTest extends TestCase
 {
-    public function testConstructMessageWithOptions()
+    public function testConstructMessageWithOptions(): void
     {
         $options = [
             'encoding'  => 'UTF-8',
@@ -60,7 +60,7 @@ class MessageFactoryTest extends TestCase
         }
     }
 
-    public function testCanCreateMessageWithMultipleRecipientsViaArrayValue()
+    public function testCanCreateMessageWithMultipleRecipientsViaArrayValue(): void
     {
         $options = [
             'from' => ['matthew@example.com' => 'Matthew'],
@@ -85,7 +85,7 @@ class MessageFactoryTest extends TestCase
         $this->assertTrue($to->has('list@example.com'));
     }
 
-    public function testIgnoresUnreconizedOptions()
+    public function testIgnoresUnreconizedOptions(): void
     {
         $options = [
             'foo' => 'bar',
@@ -94,13 +94,13 @@ class MessageFactoryTest extends TestCase
         $this->assertInstanceOf(Message::class, $mail);
     }
 
-    public function testEmptyOption()
+    public function testEmptyOption(): void
     {
         $mail = MessageFactory::getInstance();
         $this->assertInstanceOf(Message::class, $mail);
     }
 
-    public function invalidMessageOptions()
+    public function invalidMessageOptions(): array
     {
         return [
             'null' => [null],
@@ -118,7 +118,7 @@ class MessageFactoryTest extends TestCase
     /**
      * @dataProvider invalidMessageOptions
      */
-    public function testExceptionForOptionsNotArrayOrTraversable($options)
+    public function testExceptionForOptionsNotArrayOrTraversable($options): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         MessageFactory::getInstance($options);

--- a/test/MessageFactoryTest.php
+++ b/test/MessageFactoryTest.php
@@ -96,7 +96,6 @@ class MessageFactoryTest extends TestCase
 
     public function testEmptyOption()
     {
-        $options = [];
         $mail = MessageFactory::getInstance();
         $this->assertInstanceOf(Message::class, $mail);
     }

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -533,7 +533,7 @@ class MessageTest extends TestCase
             [['foo']],
             [true],
             [false],
-            [new stdClass],
+            [new stdClass()],
         ];
     }
 

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -759,7 +759,7 @@ class MessageTest extends TestCase
      * @group ZF2015-04
      * @dataProvider messageRecipients
      */
-    public function testRaisesExceptionWhenAttemptingToSerializeMessageWithCRLFInjectionViaHeader($recipientMethod): void
+    public function testExceptionWhenAttemptingToSerializeMessageWithCRLFInjectionViaHeader($recipientMethod): void
     {
         $subject = [
             'test1',

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -31,17 +31,17 @@ class MessageTest extends TestCase
     /** @var Message */
     public $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new Message();
     }
 
-    public function testInvalidByDefault()
+    public function testInvalidByDefault(): void
     {
         $this->assertFalse($this->message->isValid());
     }
 
-    public function testSetsOrigDateHeaderByDefault()
+    public function testSetsOrigDateHeaderByDefault(): void
     {
         $headers = $this->message->getHeaders();
         $this->assertInstanceOf(Headers::class, $headers);
@@ -54,26 +54,26 @@ class MessageTest extends TestCase
         $this->assertEquals($date, $test);
     }
 
-    public function testAddingFromAddressMarksAsValid()
+    public function testAddingFromAddressMarksAsValid(): void
     {
         $this->message->addFrom('test@example.com');
         $this->assertTrue($this->message->isValid());
     }
 
-    public function testHeadersMethodReturnsHeadersObject()
+    public function testHeadersMethodReturnsHeadersObject(): void
     {
         $headers = $this->message->getHeaders();
         $this->assertInstanceOf(Headers::class, $headers);
     }
 
-    public function testToMethodReturnsAddressListObject()
+    public function testToMethodReturnsAddressListObject(): void
     {
         $this->message->addTo('test@example.com');
         $to = $this->message->getTo();
         $this->assertInstanceOf(AddressList::class, $to);
     }
 
-    public function testToAddressListLivesInHeaders()
+    public function testToAddressListLivesInHeaders(): void
     {
         $this->message->addTo('test@example.com');
         $to      = $this->message->getTo();
@@ -84,14 +84,14 @@ class MessageTest extends TestCase
         $this->assertSame($header->getAddressList(), $to);
     }
 
-    public function testFromMethodReturnsAddressListObject()
+    public function testFromMethodReturnsAddressListObject(): void
     {
         $this->message->addFrom('test@example.com');
         $from = $this->message->getFrom();
         $this->assertInstanceOf(AddressList::class, $from);
     }
 
-    public function testFromAddressListLivesInHeaders()
+    public function testFromAddressListLivesInHeaders(): void
     {
         $this->message->addFrom('test@example.com');
         $from    = $this->message->getFrom();
@@ -102,14 +102,14 @@ class MessageTest extends TestCase
         $this->assertSame($header->getAddressList(), $from);
     }
 
-    public function testCcMethodReturnsAddressListObject()
+    public function testCcMethodReturnsAddressListObject(): void
     {
         $this->message->addCc('test@example.com');
         $cc = $this->message->getCc();
         $this->assertInstanceOf(AddressList::class, $cc);
     }
 
-    public function testCcAddressListLivesInHeaders()
+    public function testCcAddressListLivesInHeaders(): void
     {
         $this->message->addCc('test@example.com');
         $cc      = $this->message->getCc();
@@ -120,14 +120,14 @@ class MessageTest extends TestCase
         $this->assertSame($header->getAddressList(), $cc);
     }
 
-    public function testBccMethodReturnsAddressListObject()
+    public function testBccMethodReturnsAddressListObject(): void
     {
         $this->message->addBcc('test@example.com');
         $bcc = $this->message->getBcc();
         $this->assertInstanceOf(AddressList::class, $bcc);
     }
 
-    public function testBccAddressListLivesInHeaders()
+    public function testBccAddressListLivesInHeaders(): void
     {
         $this->message->addBcc('test@example.com');
         $bcc     = $this->message->getBcc();
@@ -138,14 +138,14 @@ class MessageTest extends TestCase
         $this->assertSame($header->getAddressList(), $bcc);
     }
 
-    public function testReplyToMethodReturnsAddressListObject()
+    public function testReplyToMethodReturnsAddressListObject(): void
     {
         $this->message->addReplyTo('test@example.com');
         $replyTo = $this->message->getReplyTo();
         $this->assertInstanceOf(AddressList::class, $replyTo);
     }
 
-    public function testReplyToAddressListLivesInHeaders()
+    public function testReplyToAddressListLivesInHeaders(): void
     {
         $this->message->addReplyTo('test@example.com');
         $replyTo = $this->message->getReplyTo();
@@ -156,26 +156,26 @@ class MessageTest extends TestCase
         $this->assertSame($header->getAddressList(), $replyTo);
     }
 
-    public function testSenderIsNullByDefault()
+    public function testSenderIsNullByDefault(): void
     {
         $this->assertNull($this->message->getSender());
     }
 
-    public function testNullSenderDoesNotCreateHeader()
+    public function testNullSenderDoesNotCreateHeader(): void
     {
         $sender = $this->message->getSender();
         $headers = $this->message->getHeaders();
         $this->assertFalse($headers->has('sender'));
     }
 
-    public function testSettingSenderCreatesAddressObject()
+    public function testSettingSenderCreatesAddressObject(): void
     {
         $this->message->setSender('test@example.com');
         $sender = $this->message->getSender();
         $this->assertInstanceOf(Address::class, $sender);
     }
 
-    public function testCanSpecifyNameWhenSettingSender()
+    public function testCanSpecifyNameWhenSettingSender(): void
     {
         $this->message->setSender('test@example.com', 'Example Test');
         $sender = $this->message->getSender();
@@ -183,7 +183,7 @@ class MessageTest extends TestCase
         $this->assertEquals('Example Test', $sender->getName());
     }
 
-    public function testCanProvideAddressObjectWhenSettingSender()
+    public function testCanProvideAddressObjectWhenSettingSender(): void
     {
         $sender = new Address('test@example.com');
         $this->message->setSender($sender);
@@ -191,7 +191,7 @@ class MessageTest extends TestCase
         $this->assertSame($sender, $test);
     }
 
-    public function testSenderAccessorsProxyToSenderHeader()
+    public function testSenderAccessorsProxyToSenderHeader(): void
     {
         $header = new Header\Sender();
         $this->message->getHeaders()->addHeader($header);
@@ -200,7 +200,7 @@ class MessageTest extends TestCase
         $this->assertSame($address, $header->getAddress());
     }
 
-    public function testCanAddFromAddressUsingName()
+    public function testCanAddFromAddressUsingName(): void
     {
         $this->message->addFrom('test@example.com', 'Example Test');
         $addresses = $this->message->getFrom();
@@ -210,7 +210,7 @@ class MessageTest extends TestCase
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testCanAddFromAddressUsingEmailAndNameAsString()
+    public function testCanAddFromAddressUsingEmailAndNameAsString(): void
     {
         $this->message->addFrom('Example Test <test@example.com>');
         $addresses = $this->message->getFrom();
@@ -220,7 +220,7 @@ class MessageTest extends TestCase
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testCanAddFromAddressUsingAddressObject()
+    public function testCanAddFromAddressUsingAddressObject(): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $this->message->addFrom($address);
@@ -231,7 +231,7 @@ class MessageTest extends TestCase
         $this->assertSame($address, $test);
     }
 
-    public function testCanAddManyFromAddressesUsingArray()
+    public function testCanAddManyFromAddressesUsingArray(): void
     {
         $addresses = [
             'test@example.com',
@@ -248,7 +248,7 @@ class MessageTest extends TestCase
         $this->assertTrue($from->has('announce@example.com'));
     }
 
-    public function testCanAddManyFromAddressesUsingAddressListObject()
+    public function testCanAddManyFromAddressesUsingAddressListObject(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -261,7 +261,7 @@ class MessageTest extends TestCase
         $this->assertTrue($from->has('test@example.com'));
     }
 
-    public function testCanSetFromListFromAddressList()
+    public function testCanSetFromListFromAddressList(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -274,7 +274,7 @@ class MessageTest extends TestCase
         $this->assertTrue($from->has('test@example.com'));
     }
 
-    public function testCanAddCcAddressUsingName()
+    public function testCanAddCcAddressUsingName(): void
     {
         $this->message->addCc('test@example.com', 'Example Test');
         $addresses = $this->message->getCc();
@@ -284,7 +284,7 @@ class MessageTest extends TestCase
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testCanAddCcAddressUsingAddressObject()
+    public function testCanAddCcAddressUsingAddressObject(): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $this->message->addCc($address);
@@ -295,7 +295,7 @@ class MessageTest extends TestCase
         $this->assertSame($address, $test);
     }
 
-    public function testCanAddManyCcAddressesUsingArray()
+    public function testCanAddManyCcAddressesUsingArray(): void
     {
         $addresses = [
             'test@example.com',
@@ -312,7 +312,7 @@ class MessageTest extends TestCase
         $this->assertTrue($cc->has('announce@example.com'));
     }
 
-    public function testCanAddManyCcAddressesUsingAddressListObject()
+    public function testCanAddManyCcAddressesUsingAddressListObject(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -325,7 +325,7 @@ class MessageTest extends TestCase
         $this->assertTrue($cc->has('test@example.com'));
     }
 
-    public function testCanSetCcListFromAddressList()
+    public function testCanSetCcListFromAddressList(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -338,7 +338,7 @@ class MessageTest extends TestCase
         $this->assertTrue($cc->has('test@example.com'));
     }
 
-    public function testCanAddBccAddressUsingName()
+    public function testCanAddBccAddressUsingName(): void
     {
         $this->message->addBcc('test@example.com', 'Example Test');
         $addresses = $this->message->getBcc();
@@ -348,7 +348,7 @@ class MessageTest extends TestCase
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testCanAddBccAddressUsingAddressObject()
+    public function testCanAddBccAddressUsingAddressObject(): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $this->message->addBcc($address);
@@ -359,7 +359,7 @@ class MessageTest extends TestCase
         $this->assertSame($address, $test);
     }
 
-    public function testCanAddManyBccAddressesUsingArray()
+    public function testCanAddManyBccAddressesUsingArray(): void
     {
         $addresses = [
             'test@example.com',
@@ -376,7 +376,7 @@ class MessageTest extends TestCase
         $this->assertTrue($bcc->has('announce@example.com'));
     }
 
-    public function testCanAddManyBccAddressesUsingAddressListObject()
+    public function testCanAddManyBccAddressesUsingAddressListObject(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -389,7 +389,7 @@ class MessageTest extends TestCase
         $this->assertTrue($bcc->has('test@example.com'));
     }
 
-    public function testCanSetBccListFromAddressList()
+    public function testCanSetBccListFromAddressList(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -402,7 +402,7 @@ class MessageTest extends TestCase
         $this->assertTrue($bcc->has('test@example.com'));
     }
 
-    public function testCanAddReplyToAddressUsingName()
+    public function testCanAddReplyToAddressUsingName(): void
     {
         $this->message->addReplyTo('test@example.com', 'Example Test');
         $addresses = $this->message->getReplyTo();
@@ -412,7 +412,7 @@ class MessageTest extends TestCase
         $this->assertEquals('Example Test', $address->getName());
     }
 
-    public function testCanAddReplyToAddressUsingAddressObject()
+    public function testCanAddReplyToAddressUsingAddressObject(): void
     {
         $address = new Address('test@example.com', 'Example Test');
         $this->message->addReplyTo($address);
@@ -423,7 +423,7 @@ class MessageTest extends TestCase
         $this->assertSame($address, $test);
     }
 
-    public function testCanAddManyReplyToAddressesUsingArray()
+    public function testCanAddManyReplyToAddressesUsingArray(): void
     {
         $addresses = [
             'test@example.com',
@@ -440,7 +440,7 @@ class MessageTest extends TestCase
         $this->assertTrue($replyTo->has('announce@example.com'));
     }
 
-    public function testCanAddManyReplyToAddressesUsingAddressListObject()
+    public function testCanAddManyReplyToAddressesUsingAddressListObject(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -453,7 +453,7 @@ class MessageTest extends TestCase
         $this->assertTrue($replyTo->has('test@example.com'));
     }
 
-    public function testCanSetReplyToListFromAddressList()
+    public function testCanSetReplyToListFromAddressList(): void
     {
         $list = new AddressList();
         $list->add('test@example.com');
@@ -466,26 +466,26 @@ class MessageTest extends TestCase
         $this->assertTrue($replyTo->has('test@example.com'));
     }
 
-    public function testSubjectIsEmptyByDefault()
+    public function testSubjectIsEmptyByDefault(): void
     {
         $this->assertNull($this->message->getSubject());
     }
 
-    public function testSubjectIsMutable()
+    public function testSubjectIsMutable(): void
     {
         $this->message->setSubject('test subject');
         $subject = $this->message->getSubject();
         $this->assertEquals('test subject', $subject);
     }
 
-    public function testSubjectIsMutableReplaceExisting()
+    public function testSubjectIsMutableReplaceExisting(): void
     {
         $this->message->setSubject('test subject');
         $this->message->setSubject('new subject');
         $this->assertSame('new subject', $this->message->getSubject());
     }
 
-    public function testSettingSubjectProxiesToHeader()
+    public function testSettingSubjectProxiesToHeader(): void
     {
         $this->message->setSubject('test subject');
         $headers = $this->message->getHeaders();
@@ -495,18 +495,18 @@ class MessageTest extends TestCase
         $this->assertEquals('test subject', $header->getFieldValue());
     }
 
-    public function testBodyIsEmptyByDefault()
+    public function testBodyIsEmptyByDefault(): void
     {
         $this->assertNull($this->message->getBody());
     }
 
-    public function testMaySetBodyFromString()
+    public function testMaySetBodyFromString(): void
     {
         $this->message->setBody('body');
         $this->assertEquals('body', $this->message->getBody());
     }
 
-    public function testMaySetBodyFromStringSerializableObject()
+    public function testMaySetBodyFromStringSerializableObject(): void
     {
         $object = new TestAsset\StringSerializableObject('body');
         $this->message->setBody($object);
@@ -514,20 +514,20 @@ class MessageTest extends TestCase
         $this->assertEquals('body', $this->message->getBodyText());
     }
 
-    public function testMaySetBodyFromMimeMessage()
+    public function testMaySetBodyFromMimeMessage(): void
     {
         $body = new MimeMessage();
         $this->message->setBody($body);
         $this->assertSame($body, $this->message->getBody());
     }
 
-    public function testMaySetNullBody()
+    public function testMaySetNullBody(): void
     {
         $this->message->setBody(null);
         $this->assertNull($this->message->getBody());
     }
 
-    public static function invalidBodyValues()
+    public static function invalidBodyValues(): array
     {
         return [
             [['foo']],
@@ -540,13 +540,13 @@ class MessageTest extends TestCase
     /**
      * @dataProvider invalidBodyValues
      */
-    public function testSettingNonScalarNonMimeNonStringSerializableValueForBodyRaisesException($body)
+    public function testSettingNonScalarNonMimeNonStringSerializableValueForBodyRaisesException($body): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->message->setBody($body);
     }
 
-    public function testSettingBodyFromSinglePartMimeMessageSetsAppropriateHeaders()
+    public function testSettingBodyFromSinglePartMimeMessageSetsAppropriateHeaders(): void
     {
         $mime = new Mime('foo-bar');
         $part = new MimePart('<b>foo</b>');
@@ -568,7 +568,7 @@ class MessageTest extends TestCase
         $this->assertEquals('text/html', $header->getFieldValue());
     }
 
-    public function testSettingUtf8MailBodyFromSinglePartMimeUtf8MessageSetsAppropriateHeaders()
+    public function testSettingUtf8MailBodyFromSinglePartMimeUtf8MessageSetsAppropriateHeaders(): void
     {
         $mime = new Mime('foo-bar');
         $part = new MimePart('UTF-8 TestString: AaÜüÄäÖöß');
@@ -589,7 +589,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testSettingBodyFromMultiPartMimeMessageSetsAppropriateHeaders()
+    public function testSettingBodyFromMultiPartMimeMessageSetsAppropriateHeaders(): void
     {
         $mime = new Mime('foo-bar');
         $text = new MimePart('foo');
@@ -614,7 +614,7 @@ class MessageTest extends TestCase
         $this->assertEquals("multipart/mixed;\r\n boundary=\"foo-bar\"", $header->getFieldValue());
     }
 
-    public function testRetrievingBodyTextFromMessageWithMultiPartMimeBodyReturnsMimeSerialization()
+    public function testRetrievingBodyTextFromMessageWithMultiPartMimeBodyReturnsMimeSerialization(): void
     {
         $mime = new Mime('foo-bar');
         $text = new MimePart('foo');
@@ -636,25 +636,25 @@ class MessageTest extends TestCase
         $this->assertContains('Content-Type: text/html', $text);
     }
 
-    public function testEncodingIsAsciiByDefault()
+    public function testEncodingIsAsciiByDefault(): void
     {
         $this->assertEquals('ASCII', $this->message->getEncoding());
     }
 
-    public function testEncodingIsMutable()
+    public function testEncodingIsMutable(): void
     {
         $this->message->setEncoding('UTF-8');
         $this->assertEquals('UTF-8', $this->message->getEncoding());
     }
 
-    public function testMessageReturnsNonEncodedSubject()
+    public function testMessageReturnsNonEncodedSubject(): void
     {
         $this->message->setSubject('This is a subject');
         $this->message->setEncoding('UTF-8');
         $this->assertEquals('This is a subject', $this->message->getSubject());
     }
 
-    public function testSettingNonAsciiEncodingForcesMimeEncodingOfSomeHeaders()
+    public function testSettingNonAsciiEncodingForcesMimeEncodingOfSomeHeaders(): void
     {
         $this->message->addTo('test@example.com', 'Laminas DevTeam');
         $this->message->addFrom('matthew@example.com', "Matthew Weier O'Phinney");
@@ -688,7 +688,7 @@ class MessageTest extends TestCase
     /**
      * @group Laminas-507
      */
-    public function testDefaultDateHeaderEncodingIsAlwaysAscii()
+    public function testDefaultDateHeaderEncodingIsAlwaysAscii(): void
     {
         $this->message->setEncoding('utf-8');
         $headers = $this->message->getHeaders();
@@ -700,7 +700,7 @@ class MessageTest extends TestCase
         $this->assertEquals($date, $test);
     }
 
-    public function testRestoreFromSerializedString()
+    public function testRestoreFromSerializedString(): void
     {
         $this->message->addTo('test@example.com', 'Example Test');
         $this->message->addFrom('matthew@example.com', "Matthew Weier O'Phinney");
@@ -715,7 +715,7 @@ class MessageTest extends TestCase
     /**
      * @group 45
      */
-    public function testCanRestoreFromSerializedStringWhenBodyContainsMultipleNewlines()
+    public function testCanRestoreFromSerializedStringWhenBodyContainsMultipleNewlines(): void
     {
         $this->message->addTo('test@example.com', 'Example Test');
         $this->message->addFrom('matthew@example.com', "Matthew Weier O'Phinney");
@@ -730,7 +730,7 @@ class MessageTest extends TestCase
     /**
      * @group Laminas-5962
      */
-    public function testPassEmptyArrayIntoSetPartsOfMimeMessageShouldReturnEmptyBodyString()
+    public function testPassEmptyArrayIntoSetPartsOfMimeMessageShouldReturnEmptyBodyString(): void
     {
         $mimeMessage = new MimeMessage();
         $mimeMessage->setParts([]);
@@ -739,7 +739,7 @@ class MessageTest extends TestCase
         $this->assertEquals('', $this->message->getBodyText());
     }
 
-    public function messageRecipients()
+    public function messageRecipients(): array
     {
         return [
             'setFrom' => ['setFrom'],
@@ -759,7 +759,7 @@ class MessageTest extends TestCase
      * @group ZF2015-04
      * @dataProvider messageRecipients
      */
-    public function testRaisesExceptionWhenAttemptingToSerializeMessageWithCRLFInjectionViaHeader($recipientMethod)
+    public function testRaisesExceptionWhenAttemptingToSerializeMessageWithCRLFInjectionViaHeader($recipientMethod): void
     {
         $subject = [
             'test1',
@@ -774,7 +774,7 @@ class MessageTest extends TestCase
     /**
      * @group ZF2015-04
      */
-    public function testDetectsCRLFInjectionViaSubject()
+    public function testDetectsCRLFInjectionViaSubject(): void
     {
         $subject = [
             'test1',
@@ -789,7 +789,7 @@ class MessageTest extends TestCase
         $this->assertNotContains("\r\n<html>", $serializedHeaders);
     }
 
-    public function testHeaderUnfoldingWorksAsExpectedForMultipartMessages()
+    public function testHeaderUnfoldingWorksAsExpectedForMultipartMessages(): void
     {
         $text = new MimePart('Test content');
         $text->type = Mime::TYPE_TEXT;
@@ -827,7 +827,7 @@ class MessageTest extends TestCase
     /**
      * @group 19
      */
-    public function testCanParseMultipartReport()
+    public function testCanParseMultipartReport(): void
     {
         $raw = file_get_contents(__DIR__ . '/_files/laminas-mail-19.txt');
         $message = Message::fromString($raw);
@@ -849,7 +849,7 @@ class MessageTest extends TestCase
         $this->assertEquals('multipart/report', $contentType->getType());
     }
 
-    public function testMailHeaderContainsZeroValue()
+    public function testMailHeaderContainsZeroValue(): void
     {
         $message =
             "From: someone@example.com\r\n"
@@ -867,7 +867,7 @@ class MessageTest extends TestCase
     /**
      * @ref CVE-2016-10033 which targeted WordPress
      */
-    public function testSecondCodeInjectionInFromHeader()
+    public function testSecondCodeInjectionInFromHeader(): void
     {
         $message = new Message();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -876,7 +876,7 @@ class MessageTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function testMessageSubjectFromString()
+    public function testMessageSubjectFromString(): void
     {
         $rawMessage = 'Subject: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
             . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=';
@@ -889,7 +889,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testMessageSubjectSetSubject()
+    public function testMessageSubjectSetSubject(): void
     {
         $mail = new Message();
         $mail->setSubject('Non “ascii” characters like accented vowels òàùèéì');
@@ -901,7 +901,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testCorrectHeaderEncodingAddHeader()
+    public function testCorrectHeaderEncodingAddHeader(): void
     {
         $mail = new Message();
         $header = new GenericHeader('X-Test', 'Non “ascii” characters like accented vowels òàùèéì');
@@ -914,7 +914,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testCorrectHeaderEncodingSetHeaders()
+    public function testCorrectHeaderEncodingSetHeaders(): void
     {
         $mail = new Message();
         $header = new GenericHeader('X-Test', 'Non “ascii” characters like accented vowels òàùèéì');
@@ -929,7 +929,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testCorrectHeaderEncodingFromString()
+    public function testCorrectHeaderEncodingFromString(): void
     {
         $mail = new Message();
         $str = 'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
@@ -944,7 +944,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testCorrectHeaderEncodingFromStringAndSetHeaders()
+    public function testCorrectHeaderEncodingFromStringAndSetHeaders(): void
     {
         $mail = new Message();
         $str = 'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
@@ -962,7 +962,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testMessageSubjectEncodingWhenEncodingSetAfterTheSubject()
+    public function testMessageSubjectEncodingWhenEncodingSetAfterTheSubject(): void
     {
         $mail = new Message();
         $mail->setSubject('hello world');
@@ -975,7 +975,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testMessageSubjectEncodingWhenEcodingSetBeforeTheSubject()
+    public function testMessageSubjectEncodingWhenEcodingSetBeforeTheSubject(): void
     {
         $mail = new Message();
         $mail->setEncoding('UTF-8');

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ModuleTest extends TestCase
 {
-    public function testInvoke()
+    public function testInvoke(): void
     {
         $module = new Module();
         $config = $module->getConfig();

--- a/test/Protocol/ProtocolTraitTest.php
+++ b/test/Protocol/ProtocolTraitTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ProtocolTraitTest extends TestCase
 {
-    public function testTls12Version()
+    public function testTls12Version(): void
     {
         $mock = $this->getMockForTrait(ProtocolTrait::class);
 

--- a/test/Protocol/ProtocolTraitTest.php
+++ b/test/Protocol/ProtocolTraitTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ProtocolTraitTest extends TestCase
 {
-    /**
-     * @requires PHP 5.6.7
-     */
     public function testTls12Version()
     {
         $mock = $this->getMockForTrait(ProtocolTrait::class);

--- a/test/Protocol/Smtp/Auth/Crammd5Test.php
+++ b/test/Protocol/Smtp/Auth/Crammd5Test.php
@@ -23,12 +23,12 @@ class Crammd5Test extends TestCase
      */
     protected $auth;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->auth = new Crammd5();
     }
 
-    public function testHmacMd5ReturnsExpectedHash()
+    public function testHmacMd5ReturnsExpectedHash(): void
     {
         $class = new ReflectionClass(Crammd5::class);
         $method = $class->getMethod('hmacMd5');
@@ -42,13 +42,13 @@ class Crammd5Test extends TestCase
         $this->assertEquals('be56fa81a5671e0c62e00134180aae2c', $result);
     }
 
-    public function testUsernameAccessors()
+    public function testUsernameAccessors(): void
     {
         $this->auth->setUsername('test');
         $this->assertEquals('test', $this->auth->getUsername());
     }
 
-    public function testPasswordAccessors()
+    public function testPasswordAccessors(): void
     {
         $this->auth->setPassword('test');
         $this->assertEquals('test', $this->auth->getPassword());

--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -19,17 +19,17 @@ class SmtpPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    protected function getPluginManager()
+    protected function getPluginManager(): SmtpPluginManager
     {
         return new SmtpPluginManager(new ServiceManager());
     }
 
-    protected function getV2InvalidPluginException()
+    protected function getV2InvalidPluginException(): string
     {
         return InvalidArgumentException::class;
     }
 
-    protected function getInstanceOf()
+    protected function getInstanceOf(): string
     {
         return Smtp::class;
     }

--- a/test/Protocol/SmtpPluginManagerFactoryTest.php
+++ b/test/Protocol/SmtpPluginManagerFactoryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class SmtpPluginManagerFactoryTest extends TestCase
 {
-    public function testFactoryReturnsPluginManager()
+    public function testFactoryReturnsPluginManager(): void
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
         $factory = new SmtpPluginManagerFactory();
@@ -37,7 +37,7 @@ class SmtpPluginManagerFactoryTest extends TestCase
     /**
      * @depends testFactoryReturnsPluginManager
      */
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
         $smtp = $this->prophesize(Smtp::class)->reveal();
@@ -54,7 +54,7 @@ class SmtpPluginManagerFactoryTest extends TestCase
     /**
      * @depends testFactoryReturnsPluginManager
      */
-    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);

--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -26,14 +26,14 @@ class SmtpTest extends TestCase
     /** @var SmtpProtocolSpy */
     public $connection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->transport  = new Smtp();
         $this->connection = new SmtpProtocolSpy();
         $this->transport->setConnection($this->connection);
     }
 
-    public function testSendMinimalMail()
+    public function testSendMinimalMail(): void
     {
         $headers = new Headers();
         $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
@@ -60,7 +60,7 @@ class SmtpTest extends TestCase
         $this->assertEquals($expectedMessage, $this->connection->getLog());
     }
 
-    public function testSendEscapedEmail()
+    public function testSendEscapedEmail(): void
     {
         $headers = new Headers();
         $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
@@ -88,13 +88,13 @@ class SmtpTest extends TestCase
         $this->assertEquals($expectedMessage, $this->connection->getLog());
     }
 
-    public function testDisconnectCallsQuit()
+    public function testDisconnectCallsQuit(): void
     {
         $this->connection->disconnect();
         $this->assertTrue($this->connection->calledQuit);
     }
 
-    public function testDisconnectResetsAuthFlag()
+    public function testDisconnectResetsAuthFlag(): void
     {
         $this->connection->connect();
         $this->connection->setSessionStatus(true);
@@ -104,7 +104,7 @@ class SmtpTest extends TestCase
         $this->assertFalse($this->connection->getAuth());
     }
 
-    public function testConnectHasVerboseErrors()
+    public function testConnectHasVerboseErrors(): void
     {
         $smtp = new TestAsset\ErroneousSmtp();
 
@@ -114,7 +114,7 @@ class SmtpTest extends TestCase
         $smtp->connect('nonexistentremote');
     }
 
-    public function testCanAvoidQuitRequest()
+    public function testCanAvoidQuitRequest(): void
     {
         $this->assertTrue($this->connection->useCompleteQuit(), 'Default behaviour must be BC');
 
@@ -141,7 +141,7 @@ class SmtpTest extends TestCase
         $this->assertFalse($connection->useCompleteQuit());
     }
 
-    public function testAuthThrowsWhenAlreadyAuthed()
+    public function testAuthThrowsWhenAlreadyAuthed(): void
     {
         $this->connection->setAuth(true);
         $this->expectException(Exception\RuntimeException::class);
@@ -149,7 +149,7 @@ class SmtpTest extends TestCase
         $this->connection->auth();
     }
 
-    public function testHeloThrowsWhenAlreadySession()
+    public function testHeloThrowsWhenAlreadySession(): void
     {
         $this->connection->helo('hostname.test');
         $this->expectException(Exception\RuntimeException::class);
@@ -157,28 +157,28 @@ class SmtpTest extends TestCase
         $this->connection->helo('hostname.test');
     }
 
-    public function testHeloThrowsWithInvalidHostname()
+    public function testHeloThrowsWithInvalidHostname(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('The input does not match the expected structure for a DNS hostname');
         $this->connection->helo("invalid\r\nhost name");
     }
 
-    public function testMailThrowsWhenNoSession()
+    public function testMailThrowsWhenNoSession(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('A valid session has not been started');
         $this->connection->mail('test@example.com');
     }
 
-    public function testRcptThrowsWhenNoMail()
+    public function testRcptThrowsWhenNoMail(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('No sender reverse path has been supplied');
         $this->connection->rcpt('test@example.com');
     }
 
-    public function testDataThrowsWhenNoRcpt()
+    public function testDataThrowsWhenNoRcpt(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('No recipient forward path has been supplied');

--- a/test/Protocol/TestAsset/ErroneousSmtp.php
+++ b/test/Protocol/TestAsset/ErroneousSmtp.php
@@ -15,7 +15,7 @@ use Laminas\Mail\Protocol\AbstractProtocol;
  */
 final class ErroneousSmtp extends AbstractProtocol
 {
-    public function connect($customRemote = null)
+    public function connect($customRemote = null): bool
     {
         return $this->_connect($customRemote);
     }

--- a/test/Storage/ImapTest.php
+++ b/test/Storage/ImapTest.php
@@ -28,7 +28,7 @@ class ImapTest extends TestCase
         }
         $this->params = ['host'     => getenv('TESTS_LAMINAS_MAIL_IMAP_HOST'),
                                'user'     => getenv('TESTS_LAMINAS_MAIL_IMAP_USER'),
-                               'password' => getenv('TESTS_LAMINAS_MAIL_IMAP_PASSWORD')];
+                               'password' => getenv('TESTS_LAMINAS_MAIL_IMAP_PASSWORD'), ];
         if (getenv('TESTS_LAMINAS_MAIL_SERVER_TESTDIR') && getenv('TESTS_LAMINAS_MAIL_SERVER_TESTDIR')) {
             if (! file_exists(getenv('TESTS_LAMINAS_MAIL_SERVER_TESTDIR') . DIRECTORY_SEPARATOR . 'inbox')
                 && ! file_exists(getenv('TESTS_LAMINAS_MAIL_SERVER_TESTDIR') . DIRECTORY_SEPARATOR . 'INBOX')
@@ -341,7 +341,7 @@ class ImapTest extends TestCase
         // we search for this folder because we can't assume an order while iterating
         $search_folders = ['subfolder'      => 'subfolder',
                                 'subfolder/test' => 'test',
-                                'INBOX'          => 'INBOX'];
+                                'INBOX'          => 'INBOX', ];
         $found_folders = [];
 
         foreach ($iterator as $localName => $folder) {

--- a/test/Storage/ImapTest.php
+++ b/test/Storage/ImapTest.php
@@ -109,7 +109,6 @@ class ImapTest extends TestCase
         new Storage\Imap([]);
     }
 
-
     public function testConnectSSL()
     {
         if (! getenv('TESTS_LAMINAS_MAIL_IMAP_SSL')) {
@@ -193,7 +192,6 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
-
     public function testClose()
     {
         $mail = new Storage\Imap($this->params);
@@ -234,7 +232,6 @@ class ImapTest extends TestCase
     {
         $mail = new Storage\Imap($this->params);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
-
 
         $sizes = $mail->getSize();
         $this->assertEquals($shouldSizes, $sizes);
@@ -368,7 +365,6 @@ class ImapTest extends TestCase
             $this->assertEquals($localName, $folder->getLocalName());
         }
     }
-
 
     public function testCountFolder()
     {
@@ -606,7 +602,6 @@ class ImapTest extends TestCase
         $this->assertEquals($status['exists'], 7);
     }
 
-
     public function testExamine()
     {
         $protocol = new Protocol\Imap($this->params['host']);
@@ -699,7 +694,6 @@ class ImapTest extends TestCase
         $mail->selectFolder('INBOX');
         $fromCount = $mail->countMessages();
         $mail->moveMessage(1, 'subfolder/test');
-
 
         $this->assertEquals($fromCount - 1, $mail->countMessages());
         $mail->selectFolder('subfolder/test');

--- a/test/Storage/ImapTest.php
+++ b/test/Storage/ImapTest.php
@@ -21,7 +21,7 @@ class ImapTest extends TestCase
 {
     protected $params;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_IMAP_ENABLED')) {
             $this->markTestSkipped('Laminas_Mail IMAP tests are not enabled');
@@ -49,7 +49,7 @@ class ImapTest extends TestCase
         }
     }
 
-    protected function cleanDir($dir)
+    protected function cleanDir($dir): void
     {
         $dh = opendir($dir);
         while (($entry = readdir($dh)) !== false) {
@@ -67,7 +67,7 @@ class ImapTest extends TestCase
         closedir($dh);
     }
 
-    protected function copyDir($dir, $dest)
+    protected function copyDir($dir, $dest): void
     {
         $dh = opendir($dir);
         while (($entry = readdir($dh)) !== false) {
@@ -86,30 +86,30 @@ class ImapTest extends TestCase
         closedir($dh);
     }
 
-    public function testConnectOk()
+    public function testConnectOk(): void
     {
         new Storage\Imap($this->params);
     }
 
-    public function testConnectConfig()
+    public function testConnectConfig(): void
     {
         new Storage\Imap(new Config\Config($this->params));
     }
 
-    public function testConnectFailure()
+    public function testConnectFailure(): void
     {
         $this->params['host'] = 'example.example';
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
-    public function testNoParams()
+    public function testNoParams(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap([]);
     }
 
-    public function testConnectSSL()
+    public function testConnectSSL(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_IMAP_SSL')) {
             return;
@@ -119,7 +119,7 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
-    public function testConnectTLS()
+    public function testConnectTLS(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_IMAP_TLS')) {
             return;
@@ -129,7 +129,7 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
-    public function testConnectSelfSignedSSL()
+    public function testConnectSelfSignedSSL(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_IMAP_SSL')) {
             return;
@@ -140,21 +140,21 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
-    public function testInvalidService()
+    public function testInvalidService(): void
     {
         $this->params['port'] = getenv('TESTS_LAMINAS_MAIL_IMAP_INVALID_PORT');
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
-    public function testWrongService()
+    public function testWrongService(): void
     {
         $this->params['port'] = getenv('TESTS_LAMINAS_MAIL_IMAP_WRONG_PORT');
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
-    public function testWrongUsername()
+    public function testWrongUsername(): void
     {
         // this also triggers ...{chars}<NL>token for coverage
         $this->params['user'] = "there is no\nnobody";
@@ -162,7 +162,7 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
-    public function testWithInstanceConstruction()
+    public function testWithInstanceConstruction(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -170,21 +170,21 @@ class ImapTest extends TestCase
         new Storage\Imap($protocol);
     }
 
-    public function testWithNotConnectedInstance()
+    public function testWithNotConnectedInstance(): void
     {
         $protocol = new Protocol\Imap();
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap($protocol);
     }
 
-    public function testWithNotLoggedInstance()
+    public function testWithNotLoggedInstance(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap($protocol);
     }
 
-    public function testWrongFolder()
+    public function testWrongFolder(): void
     {
         $this->params['folder'] = 'this folder does not exist on your server';
 
@@ -192,7 +192,7 @@ class ImapTest extends TestCase
         new Storage\Imap($this->params);
     }
 
-    public function testClose()
+    public function testClose(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->close();
@@ -207,20 +207,20 @@ class ImapTest extends TestCase
         $this->assertTrue($mail->hasTop);
     }
 */
-    public function testHasCreate()
+    public function testHasCreate(): void
     {
         $mail = new Storage\Imap($this->params);
 
         $this->assertFalse($mail->hasCreate);
     }
 
-    public function testNoop()
+    public function testNoop(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->noop();
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -228,7 +228,7 @@ class ImapTest extends TestCase
         $this->assertEquals(7, $count);
     }
 
-    public function testSize()
+    public function testSize(): void
     {
         $mail = new Storage\Imap($this->params);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
@@ -237,7 +237,7 @@ class ImapTest extends TestCase
         $this->assertEquals($shouldSizes, $sizes);
     }
 
-    public function testSingleSize()
+    public function testSingleSize(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -245,7 +245,7 @@ class ImapTest extends TestCase
         $this->assertEquals(89, $size);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -264,7 +264,7 @@ class ImapTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 */
-    public function testFetchMessageHeader()
+    public function testFetchMessageHeader(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -272,7 +272,7 @@ class ImapTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageBody()
+    public function testFetchMessageBody(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -281,7 +281,7 @@ class ImapTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -290,7 +290,7 @@ class ImapTest extends TestCase
         $this->assertEquals($mail->countMessages(), $count - 1);
     }
 
-    public function testTooLateCount()
+    public function testTooLateCount(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->close();
@@ -300,14 +300,14 @@ class ImapTest extends TestCase
         $mail->countMessages();
     }
 
-    public function testLoadUnkownFolder()
+    public function testLoadUnkownFolder(): void
     {
         $this->params['folder'] = 'UnknownFolder';
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
-    public function testChangeFolder()
+    public function testChangeFolder(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->selectFolder('subfolder/test');
@@ -315,26 +315,26 @@ class ImapTest extends TestCase
         $this->assertEquals($mail->getCurrentFolder(), 'subfolder/test');
     }
 
-    public function testUnknownFolder()
+    public function testUnknownFolder(): void
     {
         $mail = new Storage\Imap($this->params);
         $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('/Unknown/Folder/');
     }
 
-    public function testGlobalName()
+    public function testGlobalName(): void
     {
         $mail = new Storage\Imap($this->params);
         $this->assertEquals($mail->getFolders()->subfolder->__toString(), 'subfolder');
     }
 
-    public function testLocalName()
+    public function testLocalName(): void
     {
         $mail = new Storage\Imap($this->params);
         $this->assertEquals($mail->getFolders()->subfolder->key(), 'test');
     }
 
-    public function testKeyLocalName()
+    public function testKeyLocalName(): void
     {
         $mail = new Storage\Imap($this->params);
         $iterator = new \RecursiveIteratorIterator($mail->getFolders(), \RecursiveIteratorIterator::SELF_FIRST);
@@ -356,7 +356,7 @@ class ImapTest extends TestCase
         $this->assertEquals($search_folders, $found_folders);
     }
 
-    public function testSelectable()
+    public function testSelectable(): void
     {
         $mail = new Storage\Imap($this->params);
         $iterator = new \RecursiveIteratorIterator($mail->getFolders(), \RecursiveIteratorIterator::SELF_FIRST);
@@ -366,7 +366,7 @@ class ImapTest extends TestCase
         }
     }
 
-    public function testCountFolder()
+    public function testCountFolder(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -375,7 +375,7 @@ class ImapTest extends TestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testSizeFolder()
+    public function testSizeFolder(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -384,7 +384,7 @@ class ImapTest extends TestCase
         $this->assertEquals([1 => 410], $sizes);
     }
 
-    public function testFetchHeaderFolder()
+    public function testFetchHeaderFolder(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -393,14 +393,14 @@ class ImapTest extends TestCase
         $this->assertEquals('Message in subfolder', $subject);
     }
 
-    public function testHasFlag()
+    public function testHasFlag(): void
     {
         $mail = new Storage\Imap($this->params);
 
         $this->assertTrue($mail->getMessage(1)->hasFlag(Storage::FLAG_RECENT));
     }
 
-    public function testGetFlags()
+    public function testGetFlags(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -409,14 +409,14 @@ class ImapTest extends TestCase
         $this->assertContains(Storage::FLAG_RECENT, $flags);
     }
 
-    public function testRawHeader()
+    public function testRawHeader(): void
     {
         $mail = new Storage\Imap($this->params);
 
         $this->assertContains("\r\nSubject: Simple Message\r\n", $mail->getRawHeader(1));
     }
 
-    public function testUniqueId()
+    public function testUniqueId(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -440,14 +440,14 @@ class ImapTest extends TestCase
         }
     }
 
-    public function testWrongUniqueId()
+    public function testWrongUniqueId(): void
     {
         $mail = new Storage\Imap($this->params);
         $this->expectException(Exception\InvalidArgumentException::class);
         $mail->getNumberByUniqueId('this_is_an_invalid_id');
     }
 
-    public function testCreateFolder()
+    public function testCreateFolder(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->createFolder('subfolder/test1');
@@ -459,7 +459,7 @@ class ImapTest extends TestCase
         $mail->getFolders()->subfolder->test3;
     }
 
-    public function testCreateExistingFolder()
+    public function testCreateExistingFolder(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -467,7 +467,7 @@ class ImapTest extends TestCase
         $mail->createFolder('subfolder/test');
     }
 
-    public function testRemoveFolderName()
+    public function testRemoveFolderName(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->removeFolder('subfolder/test');
@@ -476,7 +476,7 @@ class ImapTest extends TestCase
         $mail->getFolders()->subfolder->test;
     }
 
-    public function testRemoveFolderInstance()
+    public function testRemoveFolderInstance(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->removeFolder($mail->getFolders()->subfolder->test);
@@ -485,7 +485,7 @@ class ImapTest extends TestCase
         $mail->getFolders()->subfolder->test;
     }
 
-    public function testRemoveInvalidFolder()
+    public function testRemoveInvalidFolder(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -493,7 +493,7 @@ class ImapTest extends TestCase
         $mail->removeFolder('thisFolderDoestNotExist');
     }
 
-    public function testRenameFolder()
+    public function testRenameFolder(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -504,7 +504,7 @@ class ImapTest extends TestCase
         $mail->renameFolder('subfolder/test', 'INBOX');
     }
 
-    public function testAppend()
+    public function testAppend(): void
     {
         $mail = new Storage\Imap($this->params);
         $count = $mail->countMessages();
@@ -524,7 +524,7 @@ class ImapTest extends TestCase
         $mail->appendMessage('');
     }
 
-    public function testCopy()
+    public function testCopy(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -544,7 +544,7 @@ class ImapTest extends TestCase
         $mail->copyMessage(1, 'justARandomFolder');
     }
 
-    public function testSetFlags()
+    public function testSetFlags(): void
     {
         $mail = new Storage\Imap($this->params);
 
@@ -576,7 +576,7 @@ class ImapTest extends TestCase
     /**
      * @group 7353
      */
-    public function testCanMarkMessageUnseen()
+    public function testCanMarkMessageUnseen(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->setFlags(1, [Storage::FLAG_UNSEEN]);
@@ -584,7 +584,7 @@ class ImapTest extends TestCase
         $this->assertTrue($message->hasFlag(Storage::FLAG_UNSEEN));
     }
 
-    public function testCapability()
+    public function testCapability(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -593,7 +593,7 @@ class ImapTest extends TestCase
         $this->assertEquals($capa[0], 'CAPABILITY');
     }
 
-    public function testSelect()
+    public function testSelect(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -602,7 +602,7 @@ class ImapTest extends TestCase
         $this->assertEquals($status['exists'], 7);
     }
 
-    public function testExamine()
+    public function testExamine(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -611,7 +611,7 @@ class ImapTest extends TestCase
         $this->assertEquals($status['exists'], 7);
     }
 
-    public function testClosedSocketNewlineToken()
+    public function testClosedSocketNewlineToken(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -621,7 +621,7 @@ class ImapTest extends TestCase
         $protocol->select("foo\nbar");
     }
 
-    public function testEscaping()
+    public function testEscaping(): void
     {
         $protocol = new Protocol\Imap();
         $this->assertEquals($protocol->escapeString('foo'), '"foo"');
@@ -634,7 +634,7 @@ class ImapTest extends TestCase
         $this->assertEquals($protocol->escapeList(['foo', 'bar']), '(foo bar)');
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -656,7 +656,7 @@ class ImapTest extends TestCase
         $protocol->fetch('UID', 99);
     }
 
-    public function testFetchByUid()
+    public function testFetchByUid(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -668,7 +668,7 @@ class ImapTest extends TestCase
         $this->assertEquals($uid, $message['UID']);
     }
 
-    public function testStore()
+    public function testStore(): void
     {
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
@@ -686,7 +686,7 @@ class ImapTest extends TestCase
         $this->assertContains('\Flagged', $result[1]);
     }
 
-    public function testMove()
+    public function testMove(): void
     {
         $mail = new Storage\Imap($this->params);
         $mail->selectFolder('subfolder/test');
@@ -700,7 +700,7 @@ class ImapTest extends TestCase
         $this->assertEquals($toCount + 1, $mail->countMessages());
     }
 
-    public function testCountFlags()
+    public function testCountFlags(): void
     {
         $mail = new Storage\Imap($this->params);
         foreach ($mail as $id => $message) {
@@ -719,7 +719,7 @@ class ImapTest extends TestCase
         $this->assertEquals($mail->countMessages(Storage::FLAG_FLAGGED), 0);
     }
 
-    public function testDelimiter()
+    public function testDelimiter(): void
     {
         $mail = new Storage\Imap($this->params);
         $delimiter = $mail->delimiter();

--- a/test/Storage/MaildirFolderTest.php
+++ b/test/Storage/MaildirFolderTest.php
@@ -23,7 +23,7 @@ class MaildirFolderTest extends TestCase
     protected $tmpdir;
     protected $subdirs = ['.', '.subfolder', '.subfolder.test'];
 
-    public function setUp()
+    public function setUp(): void
     {
         if (\strtoupper(\substr(PHP_OS, 0, 3)) == 'WIN') {
             $this->markTestSkipped('This test does not work on Windows');
@@ -95,7 +95,7 @@ class MaildirFolderTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         \chmod($this->tmpdir, 0700);
         foreach (array_reverse($this->subdirs) as $dir) {
@@ -123,33 +123,33 @@ class MaildirFolderTest extends TestCase
         }
     }
 
-    public function testLoadOk()
+    public function testLoadOk(): void
     {
         $mail = new Folder\Maildir($this->params);
         $this->assertSame(Folder\Maildir::class, \get_class($mail));
     }
 
-    public function testLoadConfig()
+    public function testLoadConfig(): void
     {
         $mail = new Folder\Maildir(new Config\Config($this->params));
         $this->assertSame(Folder\Maildir::class, \get_class($mail));
     }
 
-    public function testNoParams()
+    public function testNoParams(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('no valid dirname given in params');
         new Folder\Maildir([]);
     }
 
-    public function testLoadFailure()
+    public function testLoadFailure(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('no valid dirname given in params');
         new Folder\Maildir(['dirname' => 'This/Folder/Does/Not/Exist']);
     }
 
-    public function testLoadUnkownFolder()
+    public function testLoadUnkownFolder(): void
     {
         $this->params['folder'] = 'UnknownFolder';
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -157,7 +157,7 @@ class MaildirFolderTest extends TestCase
         new Folder\Maildir($this->params);
     }
 
-    public function testChangeFolder()
+    public function testChangeFolder(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -167,7 +167,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals($mail->getCurrentFolder(), 'subfolder.test');
     }
 
-    public function testUnknownFolder()
+    public function testUnknownFolder(): void
     {
         $mail = new Folder\Maildir($this->params);
 
@@ -176,7 +176,7 @@ class MaildirFolderTest extends TestCase
         $mail->selectFolder('/Unknown/Folder/');
     }
 
-    public function testGlobalName()
+    public function testGlobalName(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -184,7 +184,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals($mail->getFolders()->subfolder->__toString(), 'subfolder');
     }
 
-    public function testLocalName()
+    public function testLocalName(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -192,7 +192,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals($mail->getFolders()->subfolder->key(), 'test');
     }
 
-    public function testIterator()
+    public function testIterator(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -215,7 +215,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals($search_folders, $found_folders);
     }
 
-    public function testKeyLocalName()
+    public function testKeyLocalName(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -238,7 +238,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals($search_folders, $found_folders);
     }
 
-    public function testInboxEquals()
+    public function testInboxEquals(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -262,7 +262,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals($search_folders, $found_folders);
     }
 
-    public function testSelectable()
+    public function testSelectable(): void
     {
         $mail = new Folder\Maildir($this->params);
         $iterator = new RecursiveIteratorIterator($mail->getFolders(), RecursiveIteratorIterator::SELF_FIRST);
@@ -272,7 +272,7 @@ class MaildirFolderTest extends TestCase
         }
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -285,7 +285,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testSize()
+    public function testSize(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -299,7 +299,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals([1 => 467], $sizes);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Folder\Maildir($this->params);
@@ -312,7 +312,7 @@ class MaildirFolderTest extends TestCase
         $this->assertEquals('Message in subfolder', $subject);
     }
 
-    public function testNotReadableFolder()
+    public function testNotReadableFolder(): void
     {
         $this->markTestIncomplete("Fail");
         $stat = stat($this->params['dirname'] . '.subfolder');
@@ -342,7 +342,7 @@ class MaildirFolderTest extends TestCase
         }
     }
 
-    public function testNotReadableMaildir()
+    public function testNotReadableMaildir(): void
     {
         chmod($this->params['dirname'], 0);
 
@@ -351,7 +351,7 @@ class MaildirFolderTest extends TestCase
         new Folder\Maildir($this->params);
     }
 
-    public function testGetInvalidFolder()
+    public function testGetInvalidFolder(): void
     {
         $mail = new Folder\Maildir($this->params);
         $root = $mail->getFolders();
@@ -362,7 +362,7 @@ class MaildirFolderTest extends TestCase
         $mail->selectFolder('foobar');
     }
 
-    public function testGetVanishedFolder()
+    public function testGetVanishedFolder(): void
     {
         $mail = new Folder\Maildir($this->params);
         $root = $mail->getFolders();
@@ -373,7 +373,7 @@ class MaildirFolderTest extends TestCase
         $mail->selectFolder('foobar');
     }
 
-    public function testGetNotSelectableFolder()
+    public function testGetNotSelectableFolder(): void
     {
         $mail = new Folder\Maildir($this->params);
         $root = $mail->getFolders();
@@ -384,7 +384,7 @@ class MaildirFolderTest extends TestCase
         $mail->selectFolder('foobar');
     }
 
-    public function testWithAdditionalFolder()
+    public function testWithAdditionalFolder(): void
     {
         mkdir($this->params['dirname'] . '.xyyx');
         mkdir($this->params['dirname'] . '.xyyx/cur');

--- a/test/Storage/MaildirFolderTest.php
+++ b/test/Storage/MaildirFolderTest.php
@@ -272,7 +272,6 @@ class MaildirFolderTest extends TestCase
         }
     }
 
-
     public function testCount()
     {
         $this->markTestIncomplete("Fail");

--- a/test/Storage/MaildirFolderTest.php
+++ b/test/Storage/MaildirFolderTest.php
@@ -200,7 +200,7 @@ class MaildirFolderTest extends TestCase
         // we search for this folder because we can't assume an order while iterating
         $search_folders = ['subfolder'      => 'subfolder',
                                 'subfolder.test' => 'test',
-                                'INBOX'          => 'INBOX'];
+                                'INBOX'          => 'INBOX', ];
         $found_folders = [];
 
         foreach ($iterator as $localName => $folder) {
@@ -223,7 +223,7 @@ class MaildirFolderTest extends TestCase
         // we search for this folder because we can't assume an order while iterating
         $search_folders = ['subfolder'      => 'subfolder',
                                 'subfolder.test' => 'test',
-                                'INBOX'          => 'INBOX'];
+                                'INBOX'          => 'INBOX', ];
         $found_folders = [];
 
         foreach ($iterator as $localName => $folder) {

--- a/test/Storage/MaildirMessageOldTest.php
+++ b/test/Storage/MaildirMessageOldTest.php
@@ -16,7 +16,7 @@ class MaildirMessageOldTest extends TestCase
     protected $maildir;
     protected $tmpdir;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (\strtoupper(\substr(PHP_OS, 0, 3)) == 'WIN') {
             $this->markTestSkipped('This test does not work on Windows');
@@ -77,7 +77,7 @@ class MaildirMessageOldTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['cur', 'new'] as $dir) {
             if (! is_dir($this->tmpdir . $dir)) {
@@ -96,7 +96,7 @@ class MaildirMessageOldTest extends TestCase
         }
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
 
@@ -113,7 +113,7 @@ class MaildirMessageOldTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 */
-    public function testFetchMessageHeader()
+    public function testFetchMessageHeader(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
 
@@ -121,7 +121,7 @@ class MaildirMessageOldTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageBody()
+    public function testFetchMessageBody(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
 
@@ -130,7 +130,7 @@ class MaildirMessageOldTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 
-    public function testHasFlag()
+    public function testHasFlag(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
 
@@ -140,7 +140,7 @@ class MaildirMessageOldTest extends TestCase
         $this->assertFalse($mail->getMessage(2)->hasFlag(Storage::FLAG_ANSWERED));
     }
 
-    public function testGetFlags()
+    public function testGetFlags(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
 
@@ -149,13 +149,13 @@ class MaildirMessageOldTest extends TestCase
         $this->assertContains(Storage::FLAG_SEEN, $flags);
     }
 
-    public function testFetchPart()
+    public function testFetchPart(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
         $this->assertEquals($mail->getMessage(4)->getPart(2)->contentType, 'text/x-vertical');
     }
 
-    public function testPartSize()
+    public function testPartSize(): void
     {
         $mail = new TestAsset\MaildirOldMessage(['dirname' => $this->maildir]);
         $this->assertEquals($mail->getMessage(4)->getPart(2)->getSize(), 80);

--- a/test/Storage/MaildirTest.php
+++ b/test/Storage/MaildirTest.php
@@ -284,8 +284,12 @@ class MaildirTest extends TestCase
         $this->assertEquals(1, $mail->getNumberByUniqueId($mail->getUniqueId(1)));
 
         $ids = $mail->getUniqueId();
-        $should_ids = [1 => '1000000000.P1.example.org', '1000000001.P1.example.org', '1000000002.P1.example.org',
-                            '1000000003.P1.example.org', '1000000004.P1.example.org'];
+        $should_ids = [1 => '1000000000.P1.example.org',
+            '1000000001.P1.example.org',
+            '1000000002.P1.example.org',
+            '1000000003.P1.example.org',
+            '1000000004.P1.example.org',
+        ];
         foreach ($ids as $num => $id) {
             $this->assertEquals($id, $should_ids[$num]);
 

--- a/test/Storage/MaildirTest.php
+++ b/test/Storage/MaildirTest.php
@@ -184,7 +184,6 @@ class MaildirTest extends TestCase
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $shouldSizes = [1 => 397, 89, 694, 452, 497];
 
-
         $sizes = $mail->getSize();
         $this->assertEquals($shouldSizes, $sizes);
     }
@@ -387,7 +386,6 @@ class MaildirTest extends TestCase
         );
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $shouldSizes = [1 => 123, 456, 694, 452, 497];
-
 
         $sizes = $mail->getSize();
         $this->assertEquals($shouldSizes, $sizes);

--- a/test/Storage/MaildirTest.php
+++ b/test/Storage/MaildirTest.php
@@ -21,7 +21,7 @@ class MaildirTest extends TestCase
     protected $maildir;
     protected $tmpdir;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (\strtoupper(\substr(PHP_OS, 0, 3)) == 'WIN') {
             $this->markTestSkipped('This test does not work on Windows');
@@ -82,7 +82,7 @@ class MaildirTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (['cur', 'new'] as $dir) {
             if (! is_dir($this->tmpdir . $dir)) {
@@ -111,67 +111,67 @@ class MaildirTest extends TestCase
         }
     }
 
-    public function testLoadOk()
+    public function testLoadOk(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $this->assertSame(Storage\Maildir::class, \get_class($mail));
     }
 
-    public function testLoadConfig()
+    public function testLoadConfig(): void
     {
         $mail = new Storage\Maildir(new Config\Config(['dirname' => $this->maildir]));
         $this->assertSame(Storage\Maildir::class, \get_class($mail));
     }
 
-    public function testLoadFailure()
+    public function testLoadFailure(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('no valid dirname given in params');
         new Storage\Maildir(['dirname' => '/This/Dir/Does/Not/Exist']);
     }
 
-    public function testLoadInvalid()
+    public function testLoadInvalid(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid maildir given');
         new Storage\Maildir(['dirname' => __DIR__]);
     }
 
-    public function testClose()
+    public function testClose(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
         $this->assertNull($mail->close());
     }
 
-    public function testHasFlags()
+    public function testHasFlags(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $this->assertTrue($mail->hasFlags);
     }
 
-    public function testHasTop()
+    public function testHasTop(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
         $this->assertTrue($mail->hasTop);
     }
 
-    public function testHasCreate()
+    public function testHasCreate(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
         $this->assertFalse($mail->hasCreate);
     }
 
-    public function testNoop()
+    public function testNoop(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
         $this->assertTrue($mail->noop());
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -179,7 +179,7 @@ class MaildirTest extends TestCase
         $this->assertEquals(5, $count);
     }
 
-    public function testSize()
+    public function testSize(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $shouldSizes = [1 => 397, 89, 694, 452, 497];
@@ -188,7 +188,7 @@ class MaildirTest extends TestCase
         $this->assertEquals($shouldSizes, $sizes);
     }
 
-    public function testSingleSize()
+    public function testSingleSize(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -196,7 +196,7 @@ class MaildirTest extends TestCase
         $this->assertEquals(89, $size);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -213,7 +213,7 @@ class MaildirTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 */
-    public function testFetchMessageHeader()
+    public function testFetchMessageHeader(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -221,7 +221,7 @@ class MaildirTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageBody()
+    public function testFetchMessageBody(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -230,7 +230,7 @@ class MaildirTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 
-    public function testFetchWrongSize()
+    public function testFetchWrongSize(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -239,7 +239,7 @@ class MaildirTest extends TestCase
         $mail->getSize(0);
     }
 
-    public function testFetchWrongMessageBody()
+    public function testFetchWrongMessageBody(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -248,7 +248,7 @@ class MaildirTest extends TestCase
         $mail->getMessage(0);
     }
 
-    public function testFailedRemove()
+    public function testFailedRemove(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -257,7 +257,7 @@ class MaildirTest extends TestCase
         $mail->removeMessage(1);
     }
 
-    public function testHasFlag()
+    public function testHasFlag(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -267,7 +267,7 @@ class MaildirTest extends TestCase
         $this->assertFalse($mail->getMessage(2)->hasFlag(Storage::FLAG_ANSWERED));
     }
 
-    public function testGetFlags()
+    public function testGetFlags(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -276,7 +276,7 @@ class MaildirTest extends TestCase
         $this->assertContains(Storage::FLAG_SEEN, $flags);
     }
 
-    public function testUniqueId()
+    public function testUniqueId(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -299,7 +299,7 @@ class MaildirTest extends TestCase
         }
     }
 
-    public function testWrongUniqueId()
+    public function testWrongUniqueId(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
@@ -308,7 +308,7 @@ class MaildirTest extends TestCase
         $mail->getNumberByUniqueId('this_is_an_invalid_id');
     }
 
-    public function testCurIsFile()
+    public function testCurIsFile(): void
     {
         \rename($this->maildir . 'cur', $this->maildir . 'cur-isFileTest');
         \touch($this->maildir . 'cur');
@@ -318,7 +318,7 @@ class MaildirTest extends TestCase
         new Storage\Maildir(['dirname' => $this->maildir]);
     }
 
-    public function testNewIsFile()
+    public function testNewIsFile(): void
     {
         \rename($this->maildir . 'new', $this->maildir . 'new-isFileTest');
         \touch($this->maildir . 'new');
@@ -328,7 +328,7 @@ class MaildirTest extends TestCase
         new Storage\Maildir(['dirname' => $this->maildir]);
     }
 
-    public function testTmpIsFile()
+    public function testTmpIsFile(): void
     {
         \touch($this->maildir . 'tmp');
 
@@ -337,7 +337,7 @@ class MaildirTest extends TestCase
         new Storage\Maildir(['dirname' => $this->maildir]);
     }
 
-    public function testNotReadableCur()
+    public function testNotReadableCur(): void
     {
         \chmod($this->maildir . 'cur', 0);
 
@@ -346,7 +346,7 @@ class MaildirTest extends TestCase
         new Storage\Maildir(['dirname' => $this->maildir]);
     }
 
-    public function testNotReadableNew()
+    public function testNotReadableNew(): void
     {
         \chmod($this->maildir . 'new', 0);
 
@@ -355,7 +355,7 @@ class MaildirTest extends TestCase
         new Storage\Maildir(['dirname' => $this->maildir]);
     }
 
-    public function testCountFlags()
+    public function testCountFlags(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $this->assertEquals($mail->countMessages(Storage::FLAG_DELETED), 0);
@@ -366,19 +366,19 @@ class MaildirTest extends TestCase
         $this->assertEquals($mail->countMessages([Storage::FLAG_SEEN, Storage::FLAG_RECENT]), 0);
     }
 
-    public function testFetchPart()
+    public function testFetchPart(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $this->assertEquals($mail->getMessage(4)->getPart(2)->contentType, 'text/x-vertical');
     }
 
-    public function testPartSize()
+    public function testPartSize(): void
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
         $this->assertEquals($mail->getMessage(4)->getPart(2)->getSize(), 88);
     }
 
-    public function testSizePlusPlus()
+    public function testSizePlusPlus(): void
     {
         rename(
             $this->maildir . '/cur/1000000000.P1.example.org:2,S',
@@ -395,7 +395,7 @@ class MaildirTest extends TestCase
         $this->assertEquals($shouldSizes, $sizes);
     }
 
-    public function testSingleSizePlusPlus()
+    public function testSingleSizePlusPlus(): void
     {
         rename(
             $this->maildir . '/cur/1000000001.P1.example.org:2,FS',

--- a/test/Storage/MaildirWritableTest.php
+++ b/test/Storage/MaildirWritableTest.php
@@ -533,7 +533,6 @@ class MaildirWritableTest extends TestCase
         $fromCount = $mail->countMessages();
         $mail->moveMessage(1, $target);
 
-
         $this->assertEquals($fromCount - 1, $mail->countMessages());
         $mail->selectFolder($target);
         $this->assertEquals($toCount + 1, $mail->countMessages());

--- a/test/Storage/MaildirWritableTest.php
+++ b/test/Storage/MaildirWritableTest.php
@@ -514,7 +514,7 @@ class MaildirWritableTest extends TestCase
     {
         $mail = new Writable\Maildir($this->params);
         $fh = fopen('php://memory', 'rw');
-        fputs($fh, "Subject: test\r\n\r\n");
+        fwrite($fh, "Subject: test\r\n\r\n");
         fseek($fh, 0);
         $mail->appendMessage($fh);
         fclose($fh);

--- a/test/Storage/MaildirWritableTest.php
+++ b/test/Storage/MaildirWritableTest.php
@@ -22,7 +22,7 @@ class MaildirWritableTest extends TestCase
     protected $tmpdir;
     protected $subdirs = ['.', '.subfolder', '.subfolder.test'];
 
-    public function setUp()
+    public function setUp(): void
     {
         if (\strtoupper(\substr(PHP_OS, 0, 3)) == 'WIN') {
             $this->markTestSkipped('This test does not work on Windows');
@@ -94,7 +94,7 @@ class MaildirWritableTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (array_reverse($this->subdirs) as $dir) {
             if (! file_exists($this->tmpdir . $dir)) {
@@ -122,7 +122,7 @@ class MaildirWritableTest extends TestCase
         @unlink($this->tmpdir . 'maildirsize');
     }
 
-    public function testCreateFolder()
+    public function testCreateFolder(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -144,7 +144,7 @@ class MaildirWritableTest extends TestCase
         $this->subdirs[] = '.foo.bar';
     }
 
-    public function testCreateFolderEmptyPart()
+    public function testCreateFolderEmptyPart(): void
     {
         $mail = new Writable\Maildir($this->params);
         $this->expectException(Exception\RuntimeException::class);
@@ -152,7 +152,7 @@ class MaildirWritableTest extends TestCase
         $mail->createFolder('foo..bar');
     }
 
-    public function testCreateFolderSlash()
+    public function testCreateFolderSlash(): void
     {
         $mail = new Writable\Maildir($this->params);
         $this->expectException(Exception\RuntimeException::class);
@@ -160,7 +160,7 @@ class MaildirWritableTest extends TestCase
         $mail->createFolder('foo/bar');
     }
 
-    public function testCreateFolderDirectorySeparator()
+    public function testCreateFolderDirectorySeparator(): void
     {
         $mail = new Writable\Maildir($this->params);
         $this->expectException(Exception\RuntimeException::class);
@@ -168,7 +168,7 @@ class MaildirWritableTest extends TestCase
         $mail->createFolder('foo' . DIRECTORY_SEPARATOR . 'bar');
     }
 
-    public function testCreateFolderExistingDir()
+    public function testCreateFolderExistingDir(): void
     {
         $mail = new Writable\Maildir($this->params);
         unset($mail->getFolders()->subfolder->test);
@@ -178,7 +178,7 @@ class MaildirWritableTest extends TestCase
         $mail->createFolder('subfolder.test');
     }
 
-    public function testCreateExistingFolder()
+    public function testCreateExistingFolder(): void
     {
         $mail = new Writable\Maildir($this->params);
 
@@ -187,7 +187,7 @@ class MaildirWritableTest extends TestCase
         $mail->createFolder('subfolder.test');
     }
 
-    public function testRemoveFolderName()
+    public function testRemoveFolderName(): void
     {
         $mail = new Writable\Maildir($this->params);
         $mail->removeFolder('INBOX.subfolder.test');
@@ -197,7 +197,7 @@ class MaildirWritableTest extends TestCase
         $mail->selectFolder($mail->getFolders()->subfolder->test);
     }
 
-    public function testRemoveFolderInstance()
+    public function testRemoveFolderInstance(): void
     {
         $mail = new Writable\Maildir($this->params);
         $mail->removeFolder($mail->getFolders()->subfolder->test);
@@ -207,7 +207,7 @@ class MaildirWritableTest extends TestCase
         $mail->selectFolder($mail->getFolders()->subfolder->test);
     }
 
-    public function testRemoveFolderWithChildren()
+    public function testRemoveFolderWithChildren(): void
     {
         $mail = new Writable\Maildir($this->params);
 
@@ -216,7 +216,7 @@ class MaildirWritableTest extends TestCase
         $mail->removeFolder($mail->getFolders()->subfolder);
     }
 
-    public function testRemoveSelectedFolder()
+    public function testRemoveSelectedFolder(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -226,7 +226,7 @@ class MaildirWritableTest extends TestCase
         $mail->removeFolder('subfolder.test');
     }
 
-    public function testRemoveInvalidFolder()
+    public function testRemoveInvalidFolder(): void
     {
         $mail = new Writable\Maildir($this->params);
 
@@ -235,7 +235,7 @@ class MaildirWritableTest extends TestCase
         $mail->removeFolder('thisFolderDoestNotExist');
     }
 
-    public function testRenameFolder()
+    public function testRenameFolder(): void
     {
         $mail = new Writable\Maildir($this->params);
 
@@ -247,7 +247,7 @@ class MaildirWritableTest extends TestCase
         $mail->renameFolder('INBOX', 'foo');
     }
 
-    public function testRenameSelectedFolder()
+    public function testRenameSelectedFolder(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -257,7 +257,7 @@ class MaildirWritableTest extends TestCase
         $mail->renameFolder('subfolder.test', 'foo');
     }
 
-    public function testRenameToChild()
+    public function testRenameToChild(): void
     {
         $mail = new Writable\Maildir($this->params);
 
@@ -266,7 +266,7 @@ class MaildirWritableTest extends TestCase
         $mail->renameFolder('subfolder.test', 'subfolder.test.foo');
     }
 
-    public function testAppend()
+    public function testAppend(): void
     {
         $mail = new Writable\Maildir($this->params);
         $count = $mail->countMessages();
@@ -283,7 +283,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->getMessage($count + 1)->subject, 'append test');
     }
 
-    public function testCopy()
+    public function testCopy(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -304,7 +304,7 @@ class MaildirWritableTest extends TestCase
         $mail->copyMessage(1, 'justARandomFolder');
     }
 
-    public function testSetFlags()
+    public function testSetFlags(): void
     {
         $mail = new Writable\Maildir($this->params);
 
@@ -328,7 +328,7 @@ class MaildirWritableTest extends TestCase
         $mail->setFlags(1, [Storage::FLAG_RECENT]);
     }
 
-    public function testSetFlagsRemovedFile()
+    public function testSetFlagsRemovedFile(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -337,7 +337,7 @@ class MaildirWritableTest extends TestCase
         $this->expectException(Exception\InvalidArgumentException::class);
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $mail = new Writable\Maildir($this->params);
         $count = $mail->countMessages();
@@ -349,7 +349,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->countMessages(), --$count);
     }
 
-    public function testRemoveRemovedFile()
+    public function testRemoveRemovedFile(): void
     {
         $mail = new Writable\Maildir($this->params);
         unlink($this->params['dirname'] . 'cur/1000000000.P1.example.org:2,S');
@@ -359,13 +359,13 @@ class MaildirWritableTest extends TestCase
         $mail->removeMessage(1);
     }
 
-    public function testCheckQuota()
+    public function testCheckQuota(): void
     {
         $mail = new Writable\Maildir($this->params);
         $this->assertFalse($mail->checkQuota());
     }
 
-    public function testCheckQuotaDetailed()
+    public function testCheckQuotaDetailed(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -382,7 +382,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($quotaResult, $mail->checkQuota(true));
     }
 
-    public function testSetQuota()
+    public function testSetQuota(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -412,7 +412,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals(['size' => 100, 'count' => 2, 'X' => 0], $mail->getQuota(true));
     }
 
-    public function testMissingMaildirsize()
+    public function testMissingMaildirsize(): void
     {
         $mail = new Writable\Maildir($this->params);
         $this->assertEquals($mail->getQuota(true), ['size' => 3000, 'L' => 1, 'count' => 10]);
@@ -426,7 +426,7 @@ class MaildirWritableTest extends TestCase
         $mail->getQuota(true);
     }
 
-    public function testMissingMaildirsizeWithFixedQuota()
+    public function testMissingMaildirsizeWithFixedQuota(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -448,7 +448,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->getQuota(true), $quotaResult['quota']);
     }
 
-    public function testAppendMessage()
+    public function testAppendMessage(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -479,7 +479,7 @@ class MaildirWritableTest extends TestCase
         $mail->appendMessage("Subject: test\r\n\r\n");
     }
 
-    public function testRemoveMessage()
+    public function testRemoveMessage(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -490,7 +490,7 @@ class MaildirWritableTest extends TestCase
         $this->assertFalse($mail->checkQuota());
     }
 
-    public function testCopyMessage()
+    public function testCopyMessage(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -510,7 +510,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->checkQuota(true), $quotaResult);
     }
 
-    public function testAppendStream()
+    public function testAppendStream(): void
     {
         $mail = new Writable\Maildir($this->params);
         $fh = fopen('php://memory', 'rw');
@@ -522,7 +522,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->getMessage($mail->countMessages())->subject, 'test');
     }
 
-    public function testMove()
+    public function testMove(): void
     {
         $this->markTestIncomplete("Fail");
         $mail = new Writable\Maildir($this->params);
@@ -538,7 +538,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($toCount + 1, $mail->countMessages());
     }
 
-    public function testInitExisting()
+    public function testInitExisting(): void
     {
         // this should be a noop
         Writable\Maildir::initMaildir($this->params['dirname']);
@@ -546,7 +546,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->countMessages(), 5);
     }
 
-    public function testInit()
+    public function testInit(): void
     {
         $this->tearDown();
 
@@ -563,7 +563,7 @@ class MaildirWritableTest extends TestCase
         $this->assertEquals($mail->countMessages(), 0);
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->tearDown();
 

--- a/test/Storage/MaildirWritableTest.php
+++ b/test/Storage/MaildirWritableTest.php
@@ -375,9 +375,9 @@ class MaildirWritableTest extends TestCase
             'quota' => [
                     'count' => 10,
                     'L'     => 1,
-                    'size'  => 3000
+                    'size'  => 3000,
                 ],
-            'over_quota' => false
+            'over_quota' => false,
         ];
         $this->assertEquals($quotaResult, $mail->checkQuota(true));
     }
@@ -404,9 +404,9 @@ class MaildirWritableTest extends TestCase
             'quota' => [
                     'size'  => 100,
                     'count' => 2,
-                    'X'     => 0
+                    'X'     => 0,
                 ],
-            'over_quota' => true
+            'over_quota' => true,
         ];
         $this->assertEquals($quotaResult, $mail->checkQuota(true, true));
         $this->assertEquals(['size' => 100, 'count' => 2, 'X' => 0], $mail->getQuota(true));
@@ -439,9 +439,9 @@ class MaildirWritableTest extends TestCase
             'quota' => [
                     'size'  => 100,
                     'count' => 2,
-                    'X'     => 0
+                    'X'     => 0,
                 ],
-            'over_quota' => true
+            'over_quota' => true,
         ];
         $this->assertEquals($mail->checkQuota(true), $quotaResult);
 
@@ -461,9 +461,9 @@ class MaildirWritableTest extends TestCase
             'quota' => [
                     'size'  => 3000,
                     'count' => 6,
-                    'X'     => 0
+                    'X'     => 0,
                 ],
-            'over_quota' => true
+            'over_quota' => true,
         ];
         $this->assertEquals($mail->checkQuota(true), $quotaResult);
 
@@ -503,9 +503,9 @@ class MaildirWritableTest extends TestCase
             'quota' => [
                     'size'  => 3000,
                     'count' => 6,
-                    'X'     => 0
+                    'X'     => 0,
                 ],
-            'over_quota' => true
+            'over_quota' => true,
         ];
         $this->assertEquals($mail->checkQuota(true), $quotaResult);
     }

--- a/test/Storage/MboxFolderTest.php
+++ b/test/Storage/MboxFolderTest.php
@@ -271,7 +271,6 @@ class MboxFolderTest extends TestCase
         $content = $mail->getMessage(1)->getContent();
 
         $serialzed = serialize($mail);
-        $mail = null;
         $mail = unserialize($serialzed);
 
         $this->assertEquals($mail->countMessages(), $count);

--- a/test/Storage/MboxFolderTest.php
+++ b/test/Storage/MboxFolderTest.php
@@ -175,7 +175,7 @@ class MboxFolderTest extends TestCase
         $search_folders = [
             DIRECTORY_SEPARATOR . 'subfolder'                                => 'subfolder',
             DIRECTORY_SEPARATOR . 'subfolder' . DIRECTORY_SEPARATOR . 'test' => 'test',
-            DIRECTORY_SEPARATOR . 'INBOX'                                    => 'INBOX'
+            DIRECTORY_SEPARATOR . 'INBOX'                                    => 'INBOX',
         ];
         $found_folders = [];
 
@@ -199,7 +199,7 @@ class MboxFolderTest extends TestCase
         $search_folders = [
             DIRECTORY_SEPARATOR . 'subfolder'                                => 'subfolder',
             DIRECTORY_SEPARATOR . 'subfolder' . DIRECTORY_SEPARATOR . 'test' => 'test',
-            DIRECTORY_SEPARATOR . 'INBOX'                                    => 'INBOX'
+            DIRECTORY_SEPARATOR . 'INBOX'                                    => 'INBOX',
         ];
         $found_folders = [];
 

--- a/test/Storage/MboxFolderTest.php
+++ b/test/Storage/MboxFolderTest.php
@@ -24,7 +24,7 @@ class MboxFolderTest extends TestCase
     protected $tmpdir;
     protected $subdirs = ['.', 'subfolder'];
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->originalDir = __DIR__ . '/../_files/test.mbox/';
 
@@ -69,7 +69,7 @@ class MboxFolderTest extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (array_reverse($this->subdirs) as $dir) {
             $dh = opendir($this->tmpdir . $dir);
@@ -87,38 +87,38 @@ class MboxFolderTest extends TestCase
         }
     }
 
-    public function testLoadOk()
+    public function testLoadOk(): void
     {
         new Folder\Mbox($this->params);
         $this->addToAssertionCount(1);
     }
 
-    public function testLoadConfig()
+    public function testLoadConfig(): void
     {
         new Folder\Mbox(new Config\Config($this->params));
         $this->addToAssertionCount(1);
     }
 
-    public function testNoParams()
+    public function testNoParams(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Mbox([]);
     }
 
-    public function testFilenameParam()
+    public function testFilenameParam(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         // filename is not allowed in this subclass
         new Folder\Mbox(['filename' => 'foobar']);
     }
 
-    public function testLoadFailure()
+    public function testLoadFailure(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Mbox(['dirname' => 'This/Folder/Does/Not/Exist']);
     }
 
-    public function testLoadUnkownFolder()
+    public function testLoadUnknownFolder(): void
     {
         $this->params['folder'] = 'UnknownFolder';
 
@@ -126,7 +126,7 @@ class MboxFolderTest extends TestCase
         new Folder\Mbox($this->params);
     }
 
-    public function testChangeFolder()
+    public function testChangeFolder(): void
     {
         $mail = new Folder\Mbox($this->params);
 
@@ -138,35 +138,35 @@ class MboxFolderTest extends TestCase
         );
     }
 
-    public function testChangeFolderUnselectable()
+    public function testChangeFolderUnselectable(): void
     {
         $mail = new Folder\Mbox($this->params);
         $this->expectException(Exception\RuntimeException::class);
         $mail->selectFolder(DIRECTORY_SEPARATOR . 'subfolder');
     }
 
-    public function testUnknownFolder()
+    public function testUnknownFolder(): void
     {
         $mail = new Folder\Mbox($this->params);
         $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('/Unknown/Folder/');
     }
 
-    public function testGlobalName()
+    public function testGlobalName(): void
     {
         $mail = new Folder\Mbox($this->params);
 
         $this->assertEquals($mail->getFolders()->subfolder->__toString(), DIRECTORY_SEPARATOR . 'subfolder');
     }
 
-    public function testLocalName()
+    public function testLocalName(): void
     {
         $mail = new Folder\Mbox($this->params);
 
         $this->assertEquals($mail->getFolders()->subfolder->key(), 'test');
     }
 
-    public function testIterator()
+    public function testIterator(): void
     {
         $mail = new Folder\Mbox($this->params);
         $iterator = new RecursiveIteratorIterator($mail->getFolders(), RecursiveIteratorIterator::SELF_FIRST);
@@ -191,7 +191,7 @@ class MboxFolderTest extends TestCase
         $this->assertEquals($search_folders, $found_folders);
     }
 
-    public function testKeyLocalName()
+    public function testKeyLocalName(): void
     {
         $mail = new Folder\Mbox($this->params);
         $iterator = new RecursiveIteratorIterator($mail->getFolders(), RecursiveIteratorIterator::SELF_FIRST);
@@ -215,7 +215,7 @@ class MboxFolderTest extends TestCase
         $this->assertEquals($search_folders, $found_folders);
     }
 
-    public function testSelectable()
+    public function testSelectable(): void
     {
         $mail = new Folder\Mbox($this->params);
         $iterator = new RecursiveIteratorIterator($mail->getFolders(), RecursiveIteratorIterator::SELF_FIRST);
@@ -225,7 +225,7 @@ class MboxFolderTest extends TestCase
         }
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $mail = new Folder\Mbox($this->params);
 
@@ -237,7 +237,7 @@ class MboxFolderTest extends TestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testSize()
+    public function testSize(): void
     {
         $mail = new Folder\Mbox($this->params);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
@@ -250,7 +250,7 @@ class MboxFolderTest extends TestCase
         $this->assertEquals([1 => 410], $sizes);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new Folder\Mbox($this->params);
 
@@ -262,7 +262,7 @@ class MboxFolderTest extends TestCase
         $this->assertEquals('Message in subfolder', $subject);
     }
 
-    public function testSleepWake()
+    public function testSleepWake(): void
     {
         $mail = new Folder\Mbox($this->params);
 
@@ -281,7 +281,7 @@ class MboxFolderTest extends TestCase
         $this->assertEquals($mail->getMessage(1)->getContent(), $content);
     }
 
-    public function testNotMboxFile()
+    public function testNotMboxFile(): void
     {
         touch($this->params['dirname'] . 'foobar');
         $mail = new Folder\Mbox($this->params);
@@ -290,7 +290,7 @@ class MboxFolderTest extends TestCase
         $mail->getFolders()->foobar;
     }
 
-    public function testNotReadableFolder()
+    public function testNotReadableFolder(): void
     {
         $stat = stat($this->params['dirname'] . 'subfolder');
         chmod($this->params['dirname'] . 'subfolder', 0);
@@ -324,7 +324,7 @@ class MboxFolderTest extends TestCase
         }
     }
 
-    public function testGetInvalidFolder()
+    public function testGetInvalidFolder(): void
     {
         $mail = new Folder\Mbox($this->params);
         $root = $mail->getFolders();
@@ -333,7 +333,7 @@ class MboxFolderTest extends TestCase
         $mail->getFolders('foobar');
     }
 
-    public function testGetVanishedFolder()
+    public function testGetVanishedFolder(): void
     {
         $mail = new Folder\Mbox($this->params);
         $root = $mail->getFolders();

--- a/test/Storage/MboxFolderTest.php
+++ b/test/Storage/MboxFolderTest.php
@@ -225,7 +225,6 @@ class MboxFolderTest extends TestCase
         }
     }
 
-
     public function testCount()
     {
         $mail = new Folder\Mbox($this->params);

--- a/test/Storage/MboxInterfaceTest.php
+++ b/test/Storage/MboxInterfaceTest.php
@@ -21,12 +21,12 @@ class MboxInterfaceTest extends TestCase
 {
     protected $mboxFile;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->mboxFile = __DIR__ . '/../_files/test.mbox/INBOX';
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -34,21 +34,21 @@ class MboxInterfaceTest extends TestCase
         $this->assertEquals(7, $count);
     }
 
-    public function testIsset()
+    public function testIsset(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
         $this->assertTrue(isset($list[1]));
     }
 
-    public function testNotIsset()
+    public function testNotIsset(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
         $this->assertFalse(isset($list[10]));
     }
 
-    public function testArrayGet()
+    public function testArrayGet(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -56,7 +56,7 @@ class MboxInterfaceTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testArraySetFail()
+    public function testArraySetFail(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -64,7 +64,7 @@ class MboxInterfaceTest extends TestCase
         $list[1] = 'test';
     }
 
-    public function testIterationKey()
+    public function testIterationKey(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -75,7 +75,7 @@ class MboxInterfaceTest extends TestCase
         }
     }
 
-    public function testIterationIsMessage()
+    public function testIterationIsMessage(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -88,7 +88,7 @@ class MboxInterfaceTest extends TestCase
         }
     }
 
-    public function testIterationRounds()
+    public function testIterationRounds(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -100,7 +100,7 @@ class MboxInterfaceTest extends TestCase
         $this->assertEquals(7, $count);
     }
 
-    public function testIterationWithSeek()
+    public function testIterationWithSeek(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -112,7 +112,7 @@ class MboxInterfaceTest extends TestCase
         $this->assertEquals(3, $count);
     }
 
-    public function testIterationWithSeekCapped()
+    public function testIterationWithSeekCapped(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -124,7 +124,7 @@ class MboxInterfaceTest extends TestCase
         $this->assertEquals(5, $count);
     }
 
-    public function testFallback()
+    public function testFallback(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -132,7 +132,7 @@ class MboxInterfaceTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testWrongVariable()
+    public function testWrongVariable(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -140,14 +140,14 @@ class MboxInterfaceTest extends TestCase
         $list->thisdoesnotexist;
     }
 
-    public function testGetHeaders()
+    public function testGetHeaders(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
         $headers = $list[1]->getHeaders();
         $this->assertNotEmpty($headers);
     }
 
-    public function testWrongHeader()
+    public function testWrongHeader(): void
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 

--- a/test/Storage/MboxMessageOldTest.php
+++ b/test/Storage/MboxMessageOldTest.php
@@ -89,7 +89,7 @@ class MboxMessageOldTest extends TestCase
     public function testShortMbox()
     {
         $fh = fopen($this->mboxFile, 'w');
-        fputs($fh, "From \r\nSubject: test\r\nFrom \r\nSubject: test2\r\n");
+        fwrite($fh, "From \r\nSubject: test\r\nFrom \r\nSubject: test2\r\n");
         fclose($fh);
         $mail = new TestAsset\MboxOldMessage(['filename' => $this->mboxFile]);
         $this->assertEquals($mail->countMessages(), 2);

--- a/test/Storage/MboxMessageOldTest.php
+++ b/test/Storage/MboxMessageOldTest.php
@@ -16,7 +16,7 @@ class MboxMessageOldTest extends TestCase
     protected $mboxFile;
     protected $tmpdir;
 
-    public function setUp()
+    public function setUp(): void
     {
         if ($this->tmpdir == null) {
             if (getenv('TESTS_LAMINAS_MAIL_TEMPDIR') != null) {
@@ -45,12 +45,12 @@ class MboxMessageOldTest extends TestCase
         copy($this->mboxOriginalFile, $this->mboxFile);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unlink($this->mboxFile);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new TestAsset\MboxOldMessage(['filename' => $this->mboxFile]);
 
@@ -68,7 +68,7 @@ class MboxMessageOldTest extends TestCase
     }
 */
 
-    public function testFetchMessageHeader()
+    public function testFetchMessageHeader(): void
     {
         $mail = new TestAsset\MboxOldMessage(['filename' => $this->mboxFile]);
 
@@ -76,7 +76,7 @@ class MboxMessageOldTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageBody()
+    public function testFetchMessageBody(): void
     {
         $mail = new TestAsset\MboxOldMessage(['filename' => $this->mboxFile]);
 
@@ -85,7 +85,7 @@ class MboxMessageOldTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 
-    public function testShortMbox()
+    public function testShortMbox(): void
     {
         $fh = fopen($this->mboxFile, 'w');
         fwrite($fh, "From \r\nSubject: test\r\nFrom \r\nSubject: test2\r\n");

--- a/test/Storage/MboxMessageOldTest.php
+++ b/test/Storage/MboxMessageOldTest.php
@@ -85,7 +85,6 @@ class MboxMessageOldTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 
-
     public function testShortMbox()
     {
         $fh = fopen($this->mboxFile, 'w');

--- a/test/Storage/MboxTest.php
+++ b/test/Storage/MboxTest.php
@@ -23,7 +23,7 @@ class MboxTest extends TestCase
     protected $mboxFileUnix;
     protected $tmpdir;
 
-    public function setUp()
+    public function setUp(): void
     {
         if ($this->tmpdir == null) {
             if (getenv('TESTS_LAMINAS_MAIL_TEMPDIR') != null) {
@@ -52,7 +52,7 @@ class MboxTest extends TestCase
         copy($this->mboxOriginalFile, $this->mboxFile);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unlink($this->mboxFile);
 
@@ -61,37 +61,37 @@ class MboxTest extends TestCase
         }
     }
 
-    public function testLoadOk()
+    public function testLoadOk(): void
     {
         new Storage\Mbox(['filename' => $this->mboxFile]);
         $this->addToAssertionCount(1);
     }
 
-    public function testLoadConfig()
+    public function testLoadConfig(): void
     {
         new Storage\Mbox(new Config\Config(['filename' => $this->mboxFile]));
         $this->addToAssertionCount(1);
     }
 
-    public function testNoParams()
+    public function testNoParams(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Mbox([]);
     }
 
-    public function testLoadFailure()
+    public function testLoadFailure(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         new Storage\Mbox(['filename' => 'ThisFileDoesNotExist']);
     }
 
-    public function testLoadInvalid()
+    public function testLoadInvalid(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Mbox(['filename' => __FILE__]);
     }
 
-    public function testClose()
+    public function testClose(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -99,28 +99,28 @@ class MboxTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testHasTop()
+    public function testHasTop(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
         $this->assertTrue($mail->hasTop);
     }
 
-    public function testHasCreate()
+    public function testHasCreate(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
         $this->assertFalse($mail->hasCreate);
     }
 
-    public function testNoop()
+    public function testNoop(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
         $this->assertTrue($mail->noop());
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -128,7 +128,7 @@ class MboxTest extends TestCase
         $this->assertEquals(7, $count);
     }
 
-    public function testSize()
+    public function testSize(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
@@ -137,7 +137,7 @@ class MboxTest extends TestCase
         $this->assertEquals($shouldSizes, $sizes);
     }
 
-    public function testSingleSize()
+    public function testSingleSize(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -145,7 +145,7 @@ class MboxTest extends TestCase
         $this->assertEquals(89, $size);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -166,7 +166,7 @@ class MboxTest extends TestCase
     /**
      * @group 6775
      */
-    public function testFetchMessageHeaderUnix()
+    public function testFetchMessageHeaderUnix(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->getUnixMboxFile(), 'messageEOL' => "\n"]);
 
@@ -174,7 +174,7 @@ class MboxTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageHeader()
+    public function testFetchMessageHeader(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -182,7 +182,7 @@ class MboxTest extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageBody()
+    public function testFetchMessageBody(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -194,7 +194,7 @@ class MboxTest extends TestCase
     /**
      * @group 6775
      */
-    public function testFetchMessageBodyUnix()
+    public function testFetchMessageBodyUnix(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->getUnixMboxFile(), 'messageEOL' => "\n"]);
 
@@ -203,7 +203,7 @@ class MboxTest extends TestCase
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
 
-    public function testFailedRemove()
+    public function testFailedRemove(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -211,14 +211,14 @@ class MboxTest extends TestCase
         $mail->removeMessage(1);
     }
 
-    public function testCapa()
+    public function testCapabilities(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
         $capa = $mail->getCapabilities();
         $this->assertTrue(isset($capa['uniqueid']));
     }
 
-    public function testValid()
+    public function testValid(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -227,7 +227,7 @@ class MboxTest extends TestCase
         $this->assertTrue($mail->valid());
     }
 
-    public function testOutOfBounds()
+    public function testOutOfBounds(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -235,7 +235,7 @@ class MboxTest extends TestCase
         $mail->seek(INF);
     }
 
-    public function testSleepWake()
+    public function testSleepWake(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -254,7 +254,7 @@ class MboxTest extends TestCase
         $this->assertEquals($mail->getMessage(1)->getContent(), $content);
     }
 
-    public function testSleepWakeRemoved()
+    public function testSleepWakeRemoved(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -296,7 +296,7 @@ class MboxTest extends TestCase
         }
     }
 
-    public function testUniqueId()
+    public function testUniqueId(): void
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
@@ -313,7 +313,7 @@ class MboxTest extends TestCase
         }
     }
 
-    public function testShortMbox()
+    public function testShortMbox(): void
     {
         $fh = fopen($this->mboxFile, 'w');
         fwrite($fh, "From \r\nSubject: test\r\nFrom \r\nSubject: test2\r\n");
@@ -329,7 +329,7 @@ class MboxTest extends TestCase
     /**
      * @return string
      */
-    private function getUnixMboxFile()
+    private function getUnixMboxFile(): string
     {
         $this->mboxFileUnix = $this->tmpdir . 'INBOX.unix';
 

--- a/test/Storage/MboxTest.php
+++ b/test/Storage/MboxTest.php
@@ -133,7 +133,6 @@ class MboxTest extends TestCase
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
 
-
         $sizes = $mail->getSize();
         $this->assertEquals($shouldSizes, $sizes);
     }
@@ -228,7 +227,6 @@ class MboxTest extends TestCase
         $this->assertTrue($mail->valid());
     }
 
-
     public function testOutOfBounds()
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
@@ -277,8 +275,6 @@ class MboxTest extends TestCase
             );
             return;
         }
-
-
 
         $check = false;
         try {

--- a/test/Storage/MboxTest.php
+++ b/test/Storage/MboxTest.php
@@ -320,7 +320,7 @@ class MboxTest extends TestCase
     public function testShortMbox()
     {
         $fh = fopen($this->mboxFile, 'w');
-        fputs($fh, "From \r\nSubject: test\r\nFrom \r\nSubject: test2\r\n");
+        fwrite($fh, "From \r\nSubject: test\r\nFrom \r\nSubject: test2\r\n");
         fclose($fh);
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
         $this->assertEquals($mail->countMessages(), 2);

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -28,13 +28,13 @@ class MessageTest extends TestCase
     protected $file;
     protected $file2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->file = __DIR__ . '/../_files/mail.txt';
         $this->file2 = __DIR__ . '/../_files/mail_multi_to.txt';
     }
 
-    public function testInvalidFile()
+    public function testInvalidFile(): void
     {
         $this->expectException(GeneralException::class);
         new Message(['file' => '/this/file/does/not/exists']);
@@ -43,7 +43,7 @@ class MessageTest extends TestCase
     /**
      * @dataProvider filesProvider
      */
-    public function testIsMultipart($params)
+    public function testIsMultipart($params): void
     {
         $message = new Message($params);
         $this->assertTrue($message->isMultipart());
@@ -52,7 +52,7 @@ class MessageTest extends TestCase
     /**
      * @dataProvider filesProvider
      */
-    public function testGetHeader($params)
+    public function testGetHeader($params): void
     {
         $message = new Message($params);
         $this->assertEquals($message->subject, 'multipart');
@@ -61,7 +61,7 @@ class MessageTest extends TestCase
     /**
      * @dataProvider filesProvider
      */
-    public function testGetDecodedHeader($params)
+    public function testGetDecodedHeader($params): void
     {
         $message = new Message($params);
         $this->assertEquals('Peter Müller <peter-mueller@example.com>', $message->from);
@@ -70,20 +70,20 @@ class MessageTest extends TestCase
     /**
      * @dataProvider filesProvider
      */
-    public function testGetHeaderAsArray($params)
+    public function testGetHeaderAsArray($params): void
     {
         $message = new Message($params);
         $this->assertEquals(['multipart'], $message->getHeader('subject', 'array'), 'getHeader() value not match');
     }
 
-    public function testGetFirstPart()
+    public function testGetFirstPart(): void
     {
         $message = new Message(['file' => $this->file]);
 
         $this->assertEquals(substr($message->getPart(1)->getContent(), 0, 14), 'The first part');
     }
 
-    public function testGetFirstPartTwice()
+    public function testGetFirstPartTwice(): void
     {
         $message = new Message(['file' => $this->file]);
 
@@ -91,14 +91,14 @@ class MessageTest extends TestCase
         $this->assertEquals(substr($message->getPart(1)->getContent(), 0, 14), 'The first part');
     }
 
-    public function testGetWrongPart()
+    public function testGetWrongPart(): void
     {
         $this->expectException(GeneralException::class);
         $message = new Message(['file' => $this->file]);
         $message->getPart(-1);
     }
 
-    public function testNoHeaderMessage()
+    public function testNoHeaderMessage(): void
     {
         $message = new Message(['file' => __FILE__]);
 
@@ -117,14 +117,14 @@ class MessageTest extends TestCase
      * @see https://github.com/zendframework/zend-mail/pull/86
      * @see https://github.com/zendframework/zend-mail/pull/156
      */
-    public function testMessageIdHeader()
+    public function testMessageIdHeader(): void
     {
         $message = new Message(['file' => $this->file]);
         $messageId = $message->messageId;
         $this->assertEquals('<CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com>', $messageId);
     }
 
-    public function testMultipleHeader()
+    public function testMultipleHeader(): void
     {
         $raw = file_get_contents($this->file);
         $raw = "sUBject: test\r\nSubJect: test2\r\n" . $raw;
@@ -141,7 +141,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testAllowWhitespaceInEmptySingleLineHeader()
+    public function testAllowWhitespaceInEmptySingleLineHeader(): void
     {
         $src = "From: user@example.com\n"
             . "To: userpal@example.net\n"
@@ -156,7 +156,7 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testNotAllowWhitespaceInEmptyMultiLineHeader()
+    public function testNotAllowWhitespaceInEmptyMultiLineHeader(): void
     {
         $src = "From: user@example.com\nTo: userpal@example.net\n"
             . "Subject: This is your reminder\n  \n \n"
@@ -168,7 +168,7 @@ class MessageTest extends TestCase
         $message = new Message(['raw' => $src]);
     }
 
-    public function testContentTypeDecode()
+    public function testContentTypeDecode(): void
     {
         $message = new Message(['file' => $this->file]);
 
@@ -178,31 +178,31 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testSplitEmptyMessage()
+    public function testSplitEmptyMessage(): void
     {
         $this->assertEquals(Mime\Decode::splitMessageStruct('', 'xxx'), null);
     }
 
-    public function testSplitInvalidMessage()
+    public function testSplitInvalidMessage(): void
     {
         $this->expectException(MimeException\ExceptionInterface::class);
         Mime\Decode::splitMessageStruct("--xxx\n", 'xxx');
     }
 
-    public function testInvalidMailHandler()
+    public function testInvalidMailHandler(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Message(['handler' => 1]);
     }
 
-    public function testMissingId()
+    public function testMissingId(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $mail = new Storage\Mbox(['filename' => __DIR__ . '/../_files/test.mbox/INBOX']);
         new Message(['handler' => $mail]);
     }
 
-    public function testIterator()
+    public function testIterator(): void
     {
         $message = new Message(['file' => $this->file]);
         foreach (new \RecursiveIteratorIterator($message) as $num => $part) {
@@ -214,13 +214,13 @@ class MessageTest extends TestCase
         $this->assertEquals($part->contentType, 'text/x-vertical');
     }
 
-    public function testDecodeString()
+    public function testDecodeString(): void
     {
         $is = Mime\Decode::decodeQuotedPrintable('=?UTF-8?Q?"Peter M=C3=BCller"?= <peter-mueller@example.com>');
         $this->assertEquals('"Peter Müller" <peter-mueller@example.com>', $is);
     }
 
-    public function testSplitHeader()
+    public function testSplitHeader(): void
     {
         $header = 'foo; x=y; y="x"';
         $this->assertEquals(Mime\Decode::splitHeaderField($header), ['foo', 'x' => 'y', 'y' => 'x']);
@@ -230,14 +230,14 @@ class MessageTest extends TestCase
         $this->assertEquals(Mime\Decode::splitHeaderField($header, 'foo'), null);
     }
 
-    public function testSplitInvalidHeader()
+    public function testSplitInvalidHeader(): void
     {
         $this->expectException(MimeException\ExceptionInterface::class);
         $header = '';
         Mime\Decode::splitHeaderField($header);
     }
 
-    public function testSplitMessage()
+    public function testSplitMessage(): void
     {
         $header = 'Test: test';
         $body   = 'body';
@@ -256,20 +256,20 @@ class MessageTest extends TestCase
         }
     }
 
-    public function testToplines()
+    public function testTopLines(): void
     {
         $message = new Message(['headers' => file_get_contents($this->file)]);
         $this->assertStringStartsWith('multipart message', $message->getToplines());
     }
 
-    public function testNoContent()
+    public function testNoContent(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $message = new Message(['raw' => 'Subject: test']);
         $message->getContent();
     }
 
-    public function testEmptyHeader()
+    public function testEmptyHeader(): void
     {
         $message = new Message([]);
         $this->assertEquals([], $message->getHeaders()->toArray());
@@ -281,7 +281,7 @@ class MessageTest extends TestCase
         $message->subject;
     }
 
-    public function testWrongHeaderType()
+    public function testWrongHeaderType(): void
     {
         // @codingStandardsIgnoreStart
         $badMessage = unserialize(
@@ -293,7 +293,7 @@ class MessageTest extends TestCase
         $badMessage->getHeaders();
     }
 
-    public function testEmptyBody()
+    public function testEmptyBody(): void
     {
         $message = new Message([]);
         $part = null;
@@ -313,7 +313,7 @@ class MessageTest extends TestCase
     /**
      * @group Laminas-5209
      */
-    public function testCheckingHasHeaderFunctionality()
+    public function testCheckingHasHeaderFunctionality(): void
     {
         $message = new Message(['headers' => ['subject' => 'foo']]);
 
@@ -324,14 +324,14 @@ class MessageTest extends TestCase
         $this->assertFalse($message->getHeaders()->has('From'));
     }
 
-    public function testWrongMultipart()
+    public function testWrongMultipart(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $message = new Message(['raw' => "Content-Type: multipart/mixed\r\n\r\ncontent"]);
         $message->getPart(1);
     }
 
-    public function testLateFetch()
+    public function testLateFetch(): void
     {
         $mail = new Storage\Mbox(['filename' => __DIR__ . '/../_files/test.mbox/INBOX']);
 
@@ -346,7 +346,7 @@ class MessageTest extends TestCase
         $this->assertStringStartsWith('multipart message', $message->getContent());
     }
 
-    public function testManualIterator()
+    public function testManualIterator(): void
     {
         $message = new Message(['file' => $this->file]);
 
@@ -368,7 +368,7 @@ class MessageTest extends TestCase
         $this->assertEquals($message->key(), 1);
     }
 
-    public function testMessageFlagsAreSet()
+    public function testMessageFlagsAreSet(): void
     {
         $origFlags = [
             'foo' => 'bar',
@@ -382,51 +382,51 @@ class MessageTest extends TestCase
         $this->assertEquals(['bar' => 'bar', 'bat' => 'bat'], $messageFlags);
     }
 
-    public function testGetHeaderFieldSingle()
+    public function testGetHeaderFieldSingle(): void
     {
         $message = new Message(['file' => $this->file]);
         $this->assertEquals($message->getHeaderField('subject'), 'multipart');
     }
 
-    public function testGetHeaderFieldDefault()
+    public function testGetHeaderFieldDefault(): void
     {
         $message = new Message(['file' => $this->file]);
         $this->assertEquals($message->getHeaderField('content-type'), 'multipart/alternative');
     }
 
-    public function testGetHeaderFieldNamed()
+    public function testGetHeaderFieldNamed(): void
     {
         $message = new Message(['file' => $this->file]);
         $this->assertEquals($message->getHeaderField('content-type', 'boundary'), 'crazy-multipart');
     }
 
-    public function testGetHeaderFieldMissing()
+    public function testGetHeaderFieldMissing(): void
     {
         $message = new Message(['file' => $this->file]);
         $this->assertNull($message->getHeaderField('content-type', 'foo'));
     }
 
-    public function testGetHeaderFieldInvalid()
+    public function testGetHeaderFieldInvalid(): void
     {
         $this->expectException(MailException\ExceptionInterface::class);
         $message = new Message(['file' => $this->file]);
         $message->getHeaderField('fake-header-name', 'foo');
     }
 
-    public function testCaseInsensitiveMultipart()
+    public function testCaseInsensitiveMultipart(): void
     {
         $message = new Message(['raw' => "coNTent-TYpe: muLTIpaRT/x-empty\r\n\r\n"]);
         $this->assertTrue($message->isMultipart());
     }
 
-    public function testCaseInsensitiveField()
+    public function testCaseInsensitiveField(): void
     {
         $header = 'test; fOO="this is a test"';
         $this->assertEquals(Mime\Decode::splitHeaderField($header, 'Foo'), 'this is a test');
         $this->assertEquals(Mime\Decode::splitHeaderField($header, 'bar'), null);
     }
 
-    public function testSpaceInFieldName()
+    public function testSpaceInFieldName(): void
     {
         $header = 'test; foo =bar; baz      =42';
         $this->assertEquals(Mime\Decode::splitHeaderField($header, 'foo'), 'bar');
@@ -438,7 +438,7 @@ class MessageTest extends TestCase
      *
      * @see https://github.com/laminas/laminas-mail/pull/93
      */
-    public function testHeadersLosesNameQuoting()
+    public function testHeadersLosesNameQuoting(): void
     {
         $headerList = [
             'From: "Famous bearings |;" <skf@example.com>',
@@ -461,7 +461,7 @@ class MessageTest extends TestCase
     /**
      * @group Laminas-372
      */
-    public function testStrictParseMessage()
+    public function testStrictParseMessage(): void
     {
         $this->expectException(MailException\RuntimeException::class);
 
@@ -470,7 +470,7 @@ class MessageTest extends TestCase
         $message = new Message(['raw' => $raw, 'strict' => true]);
     }
 
-    public function testMultivalueToHeader()
+    public function testMultivaluedToHeader(): void
     {
         $message = new Message(['file' => $this->file2]);
         /** @var \Laminas\Mail\Header\To $header */
@@ -480,7 +480,7 @@ class MessageTest extends TestCase
         $this->assertEquals('nicpoń', $addressList->get('bar@example.pl')->getName());
     }
 
-    public function filesProvider()
+    public function filesProvider(): array
     {
         $filePath = __DIR__ . '/../_files/mail.txt';
         $fileBlankLineOnTop = __DIR__ . '/../_files/mail_blank_top_line.txt';

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -91,7 +91,6 @@ class MessageTest extends TestCase
         $this->assertEquals(substr($message->getPart(1)->getContent(), 0, 14), 'The first part');
     }
 
-
     public function testGetWrongPart()
     {
         $this->expectException(GeneralException::class);

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -372,7 +372,7 @@ class MessageTest extends TestCase
     {
         $origFlags = [
             'foo' => 'bar',
-            'baz' => 'bat'
+            'baz' => 'bat',
         ];
         $message = new Message(['flags' => $origFlags]);
 

--- a/test/Storage/Pop3Test.php
+++ b/test/Storage/Pop3Test.php
@@ -22,7 +22,7 @@ class Pop3Test extends TestCase
 {
     protected $params;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_POP3_ENABLED')) {
             $this->markTestSkipped('Laminas_Mail POP3 tests are not enabled');
@@ -54,7 +54,7 @@ class Pop3Test extends TestCase
         }
     }
 
-    protected function cleanDir($dir)
+    protected function cleanDir($dir): void
     {
         $dh = opendir($dir);
         while (($entry = readdir($dh)) !== false) {
@@ -72,7 +72,7 @@ class Pop3Test extends TestCase
         closedir($dh);
     }
 
-    protected function copyDir($dir, $dest)
+    protected function copyDir($dir, $dest): void
     {
         $dh = opendir($dir);
         while (($entry = readdir($dh)) !== false) {
@@ -91,17 +91,17 @@ class Pop3Test extends TestCase
         closedir($dh);
     }
 
-    public function testConnectOk()
+    public function testConnectOk(): void
     {
         new Storage\Pop3($this->params);
     }
 
-    public function testConnectConfig()
+    public function testConnectConfig(): void
     {
         new Storage\Pop3(new Config\Config($this->params));
     }
 
-    public function testConnectFailure()
+    public function testConnectFailure(): void
     {
         $this->params['host'] = 'example.example';
 
@@ -109,13 +109,13 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
-    public function testNoParams()
+    public function testNoParams(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new Storage\Pop3([]);
     }
 
-    public function testConnectSSL()
+    public function testConnectSSL(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_POP3_SSL')) {
             return;
@@ -126,7 +126,7 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
-    public function testConnectTLS()
+    public function testConnectTLS(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_POP3_TLS')) {
             return;
@@ -137,7 +137,7 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
-    public function testConnectSelfSignedSSL()
+    public function testConnectSelfSignedSSL(): void
     {
         if (! getenv('TESTS_LAMINAS_MAIL_POP3_SSL')) {
             return;
@@ -149,7 +149,7 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
-    public function testInvalidService()
+    public function testInvalidService(): void
     {
         $this->params['port'] = getenv('TESTS_LAMINAS_MAIL_POP3_INVALID_PORT');
 
@@ -157,7 +157,7 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
-    public function testWrongService()
+    public function testWrongService(): void
     {
         $this->params['port'] = getenv('TESTS_LAMINAS_MAIL_POP3_WRONG_PORT');
 
@@ -165,35 +165,35 @@ class Pop3Test extends TestCase
         new Storage\Pop3($this->params);
     }
 
-    public function testClose()
+    public function testClose(): void
     {
         $mail = new Storage\Pop3($this->params);
 
         $mail->close();
     }
 
-    public function testHasTop()
+    public function testHasTop(): void
     {
         $mail = new Storage\Pop3($this->params);
 
         $this->assertTrue($mail->hasTop);
     }
 
-    public function testHasCreate()
+    public function testHasCreate(): void
     {
         $mail = new Storage\Pop3($this->params);
 
         $this->assertFalse($mail->hasCreate);
     }
 
-    public function testNoop()
+    public function testNoop(): void
     {
         $mail = new Storage\Pop3($this->params);
 
         $mail->noop();
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -201,7 +201,7 @@ class Pop3Test extends TestCase
         $this->assertEquals(7, $count);
     }
 
-    public function testSize()
+    public function testSize(): void
     {
         $mail = new Storage\Pop3($this->params);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
@@ -210,7 +210,7 @@ class Pop3Test extends TestCase
         $this->assertEquals($shouldSizes, $sizes);
     }
 
-    public function testSingleSize()
+    public function testSingleSize(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -218,7 +218,7 @@ class Pop3Test extends TestCase
         $this->assertEquals(89, $size);
     }
 
-    public function testFetchHeader()
+    public function testFetchHeader(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -236,7 +236,7 @@ class Pop3Test extends TestCase
     }
 */
 
-    public function testFetchMessageHeader()
+    public function testFetchMessageHeader(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -244,7 +244,7 @@ class Pop3Test extends TestCase
         $this->assertEquals('Simple Message', $subject);
     }
 
-    public function testFetchMessageBody()
+    public function testFetchMessageBody(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -268,7 +268,7 @@ class Pop3Test extends TestCase
     }
 */
 
-    public function testWithInstanceConstruction()
+    public function testWithInstanceConstruction(): void
     {
         $protocol = new Protocol\Pop3($this->params['host']);
         $mail = new Storage\Pop3($protocol);
@@ -278,7 +278,7 @@ class Pop3Test extends TestCase
         $mail->getMessage(1);
     }
 
-    public function testRequestAfterClose()
+    public function testRequestAfterClose(): void
     {
         $mail = new Storage\Pop3($this->params);
         $mail->close();
@@ -287,13 +287,13 @@ class Pop3Test extends TestCase
         $mail->getMessage(1);
     }
 
-    public function testServerCapa()
+    public function testServerCapa(): void
     {
         $mail = new Protocol\Pop3($this->params['host']);
         $this->assertInternalType('array', $mail->capa());
     }
 
-    public function testServerUidl()
+    public function testServerUidl(): void
     {
         $mail = new Protocol\Pop3($this->params['host']);
         $mail->login($this->params['user'], $this->params['password']);
@@ -304,14 +304,14 @@ class Pop3Test extends TestCase
         $this->assertEquals($uids[1], $mail->uniqueid(1));
     }
 
-    public function testRawHeader()
+    public function testRawHeader(): void
     {
         $mail = new Storage\Pop3($this->params);
 
         $this->assertContains("\r\nSubject: Simple Message\r\n", $mail->getRawHeader(1));
     }
 
-    public function testUniqueId()
+    public function testUniqueId(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -335,7 +335,7 @@ class Pop3Test extends TestCase
         }
     }
 
-    public function testWrongUniqueId()
+    public function testWrongUniqueId(): void
     {
         $mail = new Storage\Pop3($this->params);
 
@@ -343,7 +343,7 @@ class Pop3Test extends TestCase
         $mail->getNumberByUniqueId('this_is_an_invalid_id');
     }
 
-    public function testReadAfterClose()
+    public function testReadAfterClose(): void
     {
         $protocol = new Protocol\Pop3($this->params['host']);
         $protocol->logout();
@@ -352,7 +352,7 @@ class Pop3Test extends TestCase
         $protocol->readResponse();
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $mail = new Storage\Pop3($this->params);
         $count = $mail->countMessages();
@@ -364,7 +364,7 @@ class Pop3Test extends TestCase
         $this->assertEquals($mail->countMessages(), --$count);
     }
 
-    public function testDotMessage()
+    public function testDotMessage(): void
     {
         $mail = new Storage\Pop3($this->params);
         $content = '';

--- a/test/Storage/Pop3Test.php
+++ b/test/Storage/Pop3Test.php
@@ -31,7 +31,7 @@ class Pop3Test extends TestCase
         $this->params = [
             'host'     => getenv('TESTS_LAMINAS_MAIL_POP3_HOST'),
             'user'     => getenv('TESTS_LAMINAS_MAIL_POP3_USER'),
-            'password' => getenv('TESTS_LAMINAS_MAIL_POP3_PASSWORD')
+            'password' => getenv('TESTS_LAMINAS_MAIL_POP3_PASSWORD'),
         ];
 
         if (getenv('TESTS_LAMINAS_MAIL_SERVER_TESTDIR') && getenv('TESTS_LAMINAS_MAIL_SERVER_TESTDIR')) {

--- a/test/Storage/Pop3Test.php
+++ b/test/Storage/Pop3Test.php
@@ -101,7 +101,6 @@ class Pop3Test extends TestCase
         new Storage\Pop3(new Config\Config($this->params));
     }
 
-
     public function testConnectFailure()
     {
         $this->params['host'] = 'example.example';
@@ -206,7 +205,6 @@ class Pop3Test extends TestCase
     {
         $mail = new Storage\Pop3($this->params);
         $shouldSizes = [1 => 397, 89, 694, 452, 497, 101, 139];
-
 
         $sizes = $mail->getSize();
         $this->assertEquals($shouldSizes, $sizes);

--- a/test/TestAsset/SmtpProtocolSpy.php
+++ b/test/TestAsset/SmtpProtocolSpy.php
@@ -33,11 +33,6 @@ class SmtpProtocolSpy extends Smtp
         parent::disconnect();
     }
 
-    public function helo($serverName = '127.0.0.1')
-    {
-        parent::helo($serverName);
-    }
-
     public function quit()
     {
         $this->calledQuit = true;
@@ -48,11 +43,6 @@ class SmtpProtocolSpy extends Smtp
     {
         parent::rset();
         $this->rcptTest = [];
-    }
-
-    public function mail($from)
-    {
-        parent::mail($from);
     }
 
     public function rcpt($to)
@@ -88,16 +78,6 @@ class SmtpProtocolSpy extends Smtp
     }
 
     /**
-     * Get value of mail property
-     *
-     * @return null|string
-     */
-    public function getMail()
-    {
-        return $this->mail;
-    }
-
-    /**
      * Get recipients
      *
      * @return array
@@ -128,16 +108,6 @@ class SmtpProtocolSpy extends Smtp
         $this->auth = (bool) $status;
 
         return $this;
-    }
-
-    /**
-     * Get Session Status
-     *
-     * @return bool
-     */
-    public function getSessionStatus()
-    {
-        return $this->sess;
     }
 
     /**

--- a/test/TestAsset/SmtpProtocolSpy.php
+++ b/test/TestAsset/SmtpProtocolSpy.php
@@ -20,32 +20,32 @@ class SmtpProtocolSpy extends Smtp
     protected $mail;
     protected $rcptTest = [];
 
-    public function connect()
+    public function connect(): bool
     {
         $this->connect = true;
 
         return true;
     }
 
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->connect = false;
         parent::disconnect();
     }
 
-    public function quit()
+    public function quit(): void
     {
         $this->calledQuit = true;
         parent::quit();
     }
 
-    public function rset()
+    public function rset(): void
     {
         parent::rset();
         $this->rcptTest = [];
     }
 
-    public function rcpt($to)
+    public function rcpt($to): void
     {
         parent::rcpt($to);
         $this->rcpt = true;
@@ -53,7 +53,7 @@ class SmtpProtocolSpy extends Smtp
     }
 
     // @codingStandardsIgnoreStart
-    protected function _send($request)
+    protected function _send($request): void
     {
         // Save request to internal log
         $this->_addLog($request . self::EOL);
@@ -61,7 +61,7 @@ class SmtpProtocolSpy extends Smtp
     // @codingStandardsIgnoreEnd
 
     // @codingStandardsIgnoreStart
-    protected function _expect($code, $timeout = null)
+    protected function _expect($code, $timeout = null): string
     {
         return '';
     }
@@ -72,7 +72,7 @@ class SmtpProtocolSpy extends Smtp
      *
      * @return bool
      */
-    public function isConnected()
+    public function isConnected(): bool
     {
         return $this->connect;
     }
@@ -82,7 +82,7 @@ class SmtpProtocolSpy extends Smtp
      *
      * @return array
      */
-    public function getRecipients()
+    public function getRecipients(): array
     {
         return $this->rcptTest;
     }
@@ -92,7 +92,7 @@ class SmtpProtocolSpy extends Smtp
      *
      * @return bool
      */
-    public function getAuth()
+    public function getAuth(): bool
     {
         return $this->auth;
     }
@@ -103,7 +103,7 @@ class SmtpProtocolSpy extends Smtp
      * @param  bool $status
      * @return self
      */
-    public function setAuth($status)
+    public function setAuth($status): self
     {
         $this->auth = (bool) $status;
 
@@ -116,7 +116,7 @@ class SmtpProtocolSpy extends Smtp
      * @param  bool $status
      * @return self
      */
-    public function setSessionStatus($status)
+    public function setSessionStatus($status): self
     {
         $this->sess = (bool) $status;
 

--- a/test/Transport/FactoryTest.php
+++ b/test/Transport/FactoryTest.php
@@ -26,12 +26,12 @@ class FactoryTest extends TestCase
      * @expectedException \Laminas\Mail\Transport\Exception\InvalidArgumentException
      * @param $spec
      */
-    public function testInvalidSpecThrowsInvalidArgumentException($spec)
+    public function testInvalidSpecThrowsInvalidArgumentException($spec): void
     {
         Factory::create($spec);
     }
 
-    public function invalidSpecTypeProvider()
+    public function invalidSpecTypeProvider(): array
     {
         return [
             ['spec'],
@@ -42,7 +42,7 @@ class FactoryTest extends TestCase
     /**
      *
      */
-    public function testDefaultTypeIsSendmail()
+    public function testDefaultTypeIsSendmail(): void
     {
         $transport = Factory::create();
 
@@ -53,9 +53,9 @@ class FactoryTest extends TestCase
      * @dataProvider typeProvider
      * @param $type
      */
-    public function testCanCreateClassUsingTypeKey($type)
+    public function testCanCreateClassUsingTypeKey($type): void
     {
-        set_error_handler(function ($code, $message) {
+        set_error_handler(function ($code, $message): void {
             // skip deprecation notices
         }, E_USER_DEPRECATED);
         $transport = Factory::create([
@@ -66,7 +66,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf($type, $transport);
     }
 
-    public function typeProvider()
+    public function typeProvider(): array
     {
         $types = [
             [File::class],
@@ -83,7 +83,7 @@ class FactoryTest extends TestCase
      * @param $type
      * @param $expectedClass
      */
-    public function testCanCreateClassFromTypeAlias($type, $expectedClass)
+    public function testCanCreateClassFromTypeAlias($type, $expectedClass): void
     {
         $transport = Factory::create([
             'type' => $type,
@@ -92,7 +92,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf($expectedClass, $transport);
     }
 
-    public function typeAliasProvider()
+    public function typeAliasProvider(): array
     {
         return [
             ['file', File::class],
@@ -115,7 +115,7 @@ class FactoryTest extends TestCase
     /**
      *
      */
-    public function testCanUseTraversableAsSpec()
+    public function testCanUseTraversableAsSpec(): void
     {
         $spec = new ArrayObject([
             'type' => 'inMemory',
@@ -131,14 +131,14 @@ class FactoryTest extends TestCase
      * @expectedException \Laminas\Mail\Transport\Exception\DomainException
      * @param $class
      */
-    public function testInvalidClassThrowsDomainException($class)
+    public function testInvalidClassThrowsDomainException($class): void
     {
         Factory::create([
             'type' => $class,
         ]);
     }
 
-    public function invalidClassProvider()
+    public function invalidClassProvider(): array
     {
         return [
             ['stdClass'],
@@ -149,7 +149,7 @@ class FactoryTest extends TestCase
     /**
      *
      */
-    public function testCanCreateSmtpTransportWithOptions()
+    public function testCanCreateSmtpTransportWithOptions(): void
     {
         $transport = Factory::create([
             'type' => 'smtp',
@@ -164,7 +164,7 @@ class FactoryTest extends TestCase
     /**
      *
      */
-    public function testCanCreateFileTransportWithOptions()
+    public function testCanCreateFileTransportWithOptions(): void
     {
         $transport = Factory::create([
             'type' => 'file',

--- a/test/Transport/FactoryTest.php
+++ b/test/Transport/FactoryTest.php
@@ -134,7 +134,7 @@ class FactoryTest extends TestCase
     public function testInvalidClassThrowsDomainException($class)
     {
         Factory::create([
-            'type' => $class
+            'type' => $class,
         ]);
     }
 
@@ -155,7 +155,7 @@ class FactoryTest extends TestCase
             'type' => 'smtp',
             'options' => [
                 'host' => 'somehost',
-            ]
+            ],
         ]);
 
         $this->assertEquals($transport->getOptions()->getHost(), 'somehost');
@@ -170,7 +170,7 @@ class FactoryTest extends TestCase
             'type' => 'file',
             'options' => [
                 'path' => __DIR__,
-            ]
+            ],
         ]);
 
         $this->assertEquals($transport->getOptions()->getPath(), __DIR__);

--- a/test/Transport/FactoryTest.php
+++ b/test/Transport/FactoryTest.php
@@ -57,7 +57,6 @@ class FactoryTest extends TestCase
     {
         set_error_handler(function ($code, $message) {
             // skip deprecation notices
-            return;
         }, E_USER_DEPRECATED);
         $transport = Factory::create([
             'type' => $type,

--- a/test/Transport/FileOptionsTest.php
+++ b/test/Transport/FileOptionsTest.php
@@ -21,17 +21,17 @@ class FileOptionsTest extends TestCase
     /** @var FileOptions  */
     private $options;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->options = new FileOptions();
     }
 
-    public function testPathIsSysTempDirByDefault()
+    public function testPathIsSysTempDirByDefault(): void
     {
         $this->assertEquals(sys_get_temp_dir(), $this->options->getPath());
     }
 
-    public function testDefaultCallbackIsSetByDefault()
+    public function testDefaultCallbackIsSetByDefault(): void
     {
         $callback = $this->options->getCallback();
         $this->assertInternalType('callable', $callback);
@@ -39,7 +39,7 @@ class FileOptionsTest extends TestCase
         $this->assertRegExp('#^LaminasMail_\d+_\d+\.eml$#', $test);
     }
 
-    public function testPathIsMutable()
+    public function testPathIsMutable(): void
     {
         $original = $this->options->getPath();
         $this->options->setPath(__DIR__);
@@ -48,10 +48,10 @@ class FileOptionsTest extends TestCase
         $this->assertEquals(__DIR__, $test);
     }
 
-    public function testCallbackIsMutable()
+    public function testCallbackIsMutable(): void
     {
         $original = $this->options->getCallback();
-        $new      = function ($transport) {
+        $new      = function ($transport): void {
         };
 
         $this->options->setCallback($new);
@@ -60,14 +60,14 @@ class FileOptionsTest extends TestCase
         $this->assertSame($new, $test);
     }
 
-    public function testSetCallbackThrowsWhenNotCallable()
+    public function testSetCallbackThrowsWhenNotCallable(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('expects a valid callback');
         $this->options->setCallback(null);
     }
 
-    public function testSetPathThrowsWhenPathNotWritable()
+    public function testSetPathThrowsWhenPathNotWritable(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('expects a valid path in which to write mail files');

--- a/test/Transport/FileTest.php
+++ b/test/Transport/FileTest.php
@@ -19,6 +19,9 @@ use PHPUnit\Framework\TestCase;
  */
 class FileTest extends TestCase
 {
+    /** @var string */
+    private $tempDir;
+
     public function setUp()
     {
         $this->tempDir = sys_get_temp_dir() . '/mail_file_transport';

--- a/test/Transport/FileTest.php
+++ b/test/Transport/FileTest.php
@@ -22,7 +22,7 @@ class FileTest extends TestCase
     /** @var string */
     private $tempDir;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tempDir = sys_get_temp_dir() . '/mail_file_transport';
         if (! is_dir($this->tempDir)) {
@@ -37,20 +37,20 @@ class FileTest extends TestCase
         $this->transport  = new File($fileOptions);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->cleanup($this->tempDir);
         rmdir($this->tempDir);
     }
 
-    protected function cleanup($dir)
+    protected function cleanup($dir): void
     {
         foreach (glob($dir . '/*.*') as $file) {
             unlink($file);
         }
     }
 
-    public function getMessage()
+    public function getMessage(): Message
     {
         $message = new Message();
         $message->addTo('test@example.com', 'Example Test')
@@ -69,7 +69,7 @@ class FileTest extends TestCase
         return $message;
     }
 
-    public function testReceivesMailArtifacts()
+    public function testReceivesMailArtifacts(): void
     {
         $message = $this->getMessage();
         $this->transport->send($message);
@@ -81,7 +81,7 @@ class FileTest extends TestCase
         $this->assertEquals($message->toString(), $test);
     }
 
-    public function testConstructorNoOptions()
+    public function testConstructorNoOptions(): void
     {
         $transport = new File();
         $this->assertSame(FileOptions::class, \get_class($transport->getOptions()));

--- a/test/Transport/InMemoryTest.php
+++ b/test/Transport/InMemoryTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class InMemoryTest extends TestCase
 {
-    public function getMessage()
+    public function getMessage(): Message
     {
         $message = new Message();
         $message->addTo('test@example.com', 'Example Test')
@@ -37,7 +37,7 @@ class InMemoryTest extends TestCase
         return $message;
     }
 
-    public function testReceivesMailArtifacts()
+    public function testReceivesMailArtifacts(): void
     {
         $message = $this->getMessage();
         $transport = new InMemory();
@@ -47,7 +47,7 @@ class InMemoryTest extends TestCase
         $this->assertSame($message, $transport->getLastMessage());
     }
 
-    public function testNullMessage()
+    public function testNullMessage(): void
     {
         $transport = new InMemory();
         $this->assertNull($transport->getLastMessage());

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -30,11 +30,11 @@ class SendmailTest extends TestCase
     public $additional_parameters;
     public $operating_system;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->transport = new Sendmail();
         $this->transport->setCallable(
-            function ($to, $subject, $message, $additional_headers, $additional_parameters = null) {
+            function ($to, $subject, $message, $additional_headers, $additional_parameters = null): void {
                 $this->to                    = $to;
                 $this->subject               = $subject;
                 $this->message               = $message;
@@ -45,7 +45,7 @@ class SendmailTest extends TestCase
         $this->operating_system      = strtoupper(substr(PHP_OS, 0, 3));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->to                    = null;
         $this->subject               = null;
@@ -54,7 +54,7 @@ class SendmailTest extends TestCase
         $this->additional_parameters = null;
     }
 
-    public function getMessage()
+    public function getMessage(): Message
     {
         $message = new Message();
         $message->addTo('test@example.com', 'Example Test')
@@ -73,12 +73,12 @@ class SendmailTest extends TestCase
         return $message;
     }
 
-    private function isWindows()
+    private function isWindows(): bool
     {
         return $this->operating_system === 'WIN';
     }
 
-    public function testReceivesMailArtifactsOnUnixSystems()
+    public function testReceivesMailArtifactsOnUnixSystems(): void
     {
         if ($this->isWindows()) {
             $this->markTestSkipped('This test is *nix-specific');
@@ -100,7 +100,7 @@ class SendmailTest extends TestCase
         $this->assertEquals('-R hdrs -f\'ralph@example.com\'', $this->additional_parameters);
     }
 
-    public function testReceivesMailArtifactsOnWindowsSystems()
+    public function testReceivesMailArtifactsOnWindowsSystems(): void
     {
         if (! $this->isWindows()) {
             $this->markTestSkipped('This test is Windows-specific');
@@ -124,7 +124,7 @@ class SendmailTest extends TestCase
         $this->assertNull($this->additional_parameters);
     }
 
-    public function testLinesStartingWithFullStopsArePreparedProperlyForWindows()
+    public function testLinesStartingWithFullStopsArePreparedProperlyForWindows(): void
     {
         if (! $this->isWindows()) {
             $this->markTestSkipped('This test is Windows-specific');
@@ -136,7 +136,7 @@ class SendmailTest extends TestCase
         $this->assertContains("line.\n.. This", trim($this->message));
     }
 
-    public function testAssertSubjectEncoded()
+    public function testAssertSubjectEncoded(): void
     {
         $message = $this->getMessage();
         $message->setEncoding('UTF-8');
@@ -144,7 +144,7 @@ class SendmailTest extends TestCase
         $this->assertEquals('=?UTF-8?Q?Testing=20Laminas\Mail\Transport\Sendmail?=', $this->subject);
     }
 
-    public function testCodeInjectionInFromHeader()
+    public function testCodeInjectionInFromHeader(): void
     {
         $this->expectException(RuntimeException::class);
         $message = $this->getMessage();
@@ -156,7 +156,7 @@ class SendmailTest extends TestCase
         $this->transport->send($message);
     }
 
-    public function testValidEmailLocaDomainInFromHeader()
+    public function testValidEmailLocaDomainInFromHeader(): void
     {
         $message = $this->getMessage();
         $message->setBody('This is the text of the email.');
@@ -171,7 +171,7 @@ class SendmailTest extends TestCase
     /**
      * @ref CVE-2016-10033 which targeted WordPress
      */
-    public function testPrepareParametersEscapesSenderUsingEscapeShellArg()
+    public function testPrepareParametersEscapesSenderUsingEscapeShellArg(): void
     {
         // @codingStandardsIgnoreStart
         $injectedEmail = 'user@xenial(tmp1 -be ${run{${substr{0}{1}{$spool_directory}}usr${substr{0}{1}{$spool_directory}}bin${substr{0}{1}{$spool_directory}}touch${substr{10}{1}{$tod_log}}${substr{0}{1}{$spool_directory}}tmp${substr{0}{1}{$spool_directory}}test}}  tmp2)';
@@ -194,7 +194,7 @@ class SendmailTest extends TestCase
     /**
      * @ref CVE-2016-10033 which targeted WordPress
      */
-    public function testPrepareParametersEscapesFromAddressUsingEscapeShellArg()
+    public function testPrepareParametersEscapesFromAddressUsingEscapeShellArg(): void
     {
         // @codingStandardsIgnoreStart
         $injectedEmail = 'user@xenial(tmp1 -be ${run{${substr{0}{1}{$spool_directory}}usr${substr{0}{1}{$spool_directory}}bin${substr{0}{1}{$spool_directory}}touch${substr{10}{1}{$tod_log}}${substr{0}{1}{$spool_directory}}tmp${substr{0}{1}{$spool_directory}}test}}  tmp2)';
@@ -217,7 +217,7 @@ class SendmailTest extends TestCase
         $this->assertEquals(' -f' . escapeshellarg($injectedEmail), $parameters);
     }
 
-    public function testTrimmedParameters()
+    public function testTrimmedParameters(): void
     {
         $this->transport->setParameters([' -R', 'hdrs ']);
 
@@ -227,7 +227,7 @@ class SendmailTest extends TestCase
         $this->assertSame('-R hdrs', $r->getValue($this->transport));
     }
 
-    public function testAllowMessageWithEmptyToHeaderButHasCcHeader()
+    public function testAllowMessageWithEmptyToHeaderButHasCcHeader(): void
     {
         $message = new Message();
         $message->addCc('matthew@example.com')
@@ -239,7 +239,7 @@ class SendmailTest extends TestCase
         $this->assertContains('Sender: Ralph Schindler <ralph@example.com>', $this->additional_headers);
     }
 
-    public function testAllowMessageWithEmptyToHeaderButHasBccHeader()
+    public function testAllowMessageWithEmptyToHeaderButHasBccHeader(): void
     {
         $message = new Message();
         $message->addBcc('list@example.com', 'Example, List')
@@ -251,7 +251,7 @@ class SendmailTest extends TestCase
         $this->assertContains('Sender: Ralph Schindler <ralph@example.com>', $this->additional_headers);
     }
 
-    public function testDoNotAllowMessageWithoutToAndCcAndBccHeaders()
+    public function testDoNotAllowMessageWithoutToAndCcAndBccHeaders(): void
     {
         $message = new Message();
         $message->setSender('ralph@example.com', 'Ralph Schindler')
@@ -265,7 +265,7 @@ class SendmailTest extends TestCase
     /**
      * @see https://github.com/laminas/laminas-mail/issues/19
      */
-    public function testHeadersToAndSubjectAreNotDuplicated()
+    public function testHeadersToAndSubjectAreNotDuplicated(): void
     {
         $message = new Message();
         $message

--- a/test/Transport/SmtpTest.php
+++ b/test/Transport/SmtpTest.php
@@ -31,14 +31,14 @@ class SmtpTest extends TestCase
     /** @var SmtpProtocolSpy */
     public $connection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->transport  = new Smtp();
         $this->connection = new SmtpProtocolSpy();
         $this->transport->setConnection($this->connection);
     }
 
-    public function getMessage()
+    public function getMessage(): Message
     {
         $message = new Message();
         $message->addTo('test@example.com', 'Example Test');
@@ -62,7 +62,7 @@ class SmtpTest extends TestCase
     /**
      *  Per RFC 2822 3.6
      */
-    public function testSendMailWithoutMinimalHeaders()
+    public function testSendMailWithoutMinimalHeaders(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage(
@@ -76,7 +76,7 @@ class SmtpTest extends TestCase
      *  Per RFC 2821 3.3 (page 18)
      *  - RCPT (recipient) must be called before DATA (headers or body)
      */
-    public function testSendMailWithoutRecipient()
+    public function testSendMailWithoutRecipient(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('at least one recipient if the message has at least one header or body');
@@ -85,7 +85,7 @@ class SmtpTest extends TestCase
         $this->transport->send($message);
     }
 
-    public function testSendMailWithEnvelopeFrom()
+    public function testSendMailWithEnvelopeFrom(): void
     {
         $message = $this->getMessage();
         $envelope = new Envelope([
@@ -101,7 +101,7 @@ class SmtpTest extends TestCase
         $this->assertContains("From: test@example.com,\r\n Matthew <matthew@example.com>\r\n", $data);
     }
 
-    public function testSendMailWithEnvelopeTo()
+    public function testSendMailWithEnvelopeTo(): void
     {
         $message = $this->getMessage();
         $envelope = new Envelope([
@@ -116,7 +116,7 @@ class SmtpTest extends TestCase
         $this->assertContains('To: Example Test <test@example.com>', $data);
     }
 
-    public function testSendMailWithEnvelope()
+    public function testSendMailWithEnvelope(): void
     {
         $message = $this->getMessage();
         $to = ['users@example.com', 'dev@example.com'];
@@ -135,7 +135,7 @@ class SmtpTest extends TestCase
         $this->assertContains('RCPT TO:<dev@example.com>', $data);
     }
 
-    public function testSendMinimalMail()
+    public function testSendMinimalMail(): void
     {
         $headers = new Headers();
         $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
@@ -157,7 +157,7 @@ class SmtpTest extends TestCase
         $this->assertContains($expectedMessage, $this->connection->getLog());
     }
 
-    public function testSendMinimalMailWithoutSender()
+    public function testSendMinimalMailWithoutSender(): void
     {
         $headers = new Headers();
         $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
@@ -179,7 +179,7 @@ class SmtpTest extends TestCase
         $this->assertContains($expectedMessage, $this->connection->getLog());
     }
 
-    public function testReceivesMailArtifacts()
+    public function testReceivesMailArtifacts(): void
     {
         $message = $this->getMessage();
         $this->transport->send($message);
@@ -199,7 +199,7 @@ class SmtpTest extends TestCase
         $this->assertContains("\r\n\r\nThis is only a test.", $data, $data);
     }
 
-    public function testCanUseAuthenticationExtensionsViaPluginManager()
+    public function testCanUseAuthenticationExtensionsViaPluginManager(): void
     {
         $options    = new SmtpOptions([
             'connection_class' => 'login',
@@ -215,25 +215,25 @@ class SmtpTest extends TestCase
         $this->assertEquals('password', $connection->getPassword());
     }
 
-    public function testSetAutoDisconnect()
+    public function testSetAutoDisconnect(): void
     {
         $this->transport->setAutoDisconnect(false);
         $this->assertFalse($this->transport->getAutoDisconnect());
     }
 
-    public function testGetDefaultAutoDisconnectValue()
+    public function testGetDefaultAutoDisconnectValue(): void
     {
         $this->assertTrue($this->transport->getAutoDisconnect());
     }
 
-    public function testAutoDisconnectTrue()
+    public function testAutoDisconnectTrue(): void
     {
         $this->connection->connect();
         unset($this->transport);
         $this->assertFalse($this->connection->hasSession());
     }
 
-    public function testAutoDisconnectFalse()
+    public function testAutoDisconnectFalse(): void
     {
         $this->connection->connect();
         $this->transport->setAutoDisconnect(false);
@@ -241,7 +241,7 @@ class SmtpTest extends TestCase
         $this->assertTrue($this->connection->isConnected());
     }
 
-    public function testDisconnect()
+    public function testDisconnect(): void
     {
         $this->connection->connect();
         $this->assertTrue($this->connection->isConnected());
@@ -249,7 +249,7 @@ class SmtpTest extends TestCase
         $this->assertFalse($this->connection->isConnected());
     }
 
-    public function testDisconnectSendReconnects()
+    public function testDisconnectSendReconnects(): void
     {
         $this->assertFalse($this->connection->hasSession());
         $this->transport->send($this->getMessage());
@@ -261,7 +261,7 @@ class SmtpTest extends TestCase
         $this->assertTrue($this->connection->hasSession());
     }
 
-    public function testAutoReconnect()
+    public function testAutoReconnect(): void
     {
         $options = new SmtpOptions();
         $options->setConnectionTimeLimit(5 * 3600);

--- a/test/Transport/SmtpTest.php
+++ b/test/Transport/SmtpTest.php
@@ -321,7 +321,6 @@ class SmtpTest extends TestCase
 
         $this->transport->setPluginManager($pluginManagerMock);
 
-
         // Send the first email - first connect()
         $this->transport->send($this->getMessage());
 
@@ -334,13 +333,11 @@ class SmtpTest extends TestCase
         $connectedTimeAfterFirstMail = $connectedTimeProperty->getValue($this->transport);
         $this->assertNotNull($connectedTimeAfterFirstMail);
 
-
         // Send the second email - no new connect()
         $this->transport->send($this->getMessage());
 
         // Make sure that there was no new connect() (and no new timestamp was written)
         $this->assertEquals($connectedTimeAfterFirstMail, $connectedTimeProperty->getValue($this->transport));
-
 
         // Manipulate the timestamp to trigger the auto-reconnect
         $connectedTimeProperty->setValue($this->transport, time() - 10 * 3600);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Applies code style fixes to tests:
- add return types
- add parameter types
- cleanup dead code
- fixup phpdoc

... see commits for details
