### PR TITLE
Allow code to access the last response string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#110](https://github.com/laminas/laminas-mail/pull/110) adds a Protocol\Imap::getLastResponseLine() function.
 
 ### Deprecated
 

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -29,6 +29,12 @@ class Imap
     protected $tagCount = 0;
 
     /**
+     * Last line returned from server
+     * @var string|null
+     */
+    protected $lastResponseLine;
+
+    /**
      * Public constructor
      *
      * @param  string       $host           hostname or IP address of IMAP server, if given connect() is called
@@ -128,8 +134,8 @@ class Imap
      */
     protected function assumedNextLine($start)
     {
-        $line = $this->nextLine();
-        return strpos($line, $start) === 0;
+        $this->lastResponseLine = $this->nextLine();
+        return strpos($this->lastResponseLine, $start) === 0;
     }
 
     /**
@@ -143,9 +149,9 @@ class Imap
         $line = $this->nextLine();
 
         // separate tag from line
-        list($tag, $line) = explode(' ', $line, 2);
+        list($tag, $this->lastResponseLine) = explode(' ', $line, 2);
 
-        return $line;
+        return $this->lastResponseLine;
     }
 
     /**
@@ -821,4 +827,13 @@ class Imap
         }
         return [];
     }
+
+    /**
+     * @return string|null
+     */
+    public function getLastResponseLine()
+    {
+        return $this->lastResponseLine;
+    }
+
 }

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -835,5 +835,4 @@ class Imap
     {
         return $this->lastResponseLine;
     }
-
 }

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -302,7 +302,7 @@ class Imap
         } elseif ($tokens[0] == 'NO') {
             return false;
         }
-        return;
+        return null;
     }
 
     /**

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -32,7 +32,7 @@ class Imap
      * Last line returned from server
      * @var string|null
      */
-    protected $lastResponseLine;
+    private $lastResponseLine;
 
     /**
      * Public constructor

--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -149,7 +149,7 @@ class Imap
         $line = $this->nextLine();
 
         // separate tag from line
-        list($tag, $this->lastResponseLine) = explode(' ', $line, 2);
+        [$tag, $this->lastResponseLine] = explode(' ', $line, 2);
 
         return $this->lastResponseLine;
     }


### PR DESCRIPTION
This does make the class stateful - OTOH that reflects the nature of an IMAP session.
- requestAndResponse() provides very rudimentary response for debugging negative responses
- it is at times useful to see the exact response of the server
- "NO [AUTHENTICATIONFAILED] Authentication failed." is far more informative than a FALSE
- also, there's currently no way to distinguish between different error states
- e.g. the above and "NO [INSUFFICIENTGROVEL] Zot!"

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

- Are you adding something the library currently does not support?
  - Why should it be added? Users of this library are likely to be of technical nature, and might need the information for troubleshooting
  - What will it enable? A more verbose error reporting, if requested by the user.
  - How will the code be used? `$imapProtocol->login() or log_error($imapProtocol->getLastResponse());`
  - TARGET THE develop BRANCH
