### PR TITLE
Handle RFC5987 format in headers

### DIFF
--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -57,7 +57,7 @@ class ContentDisposition implements UnstructuredInterface
         $header->setDisposition($parts[0]);
 
         if (isset($parts[1])) {
-            $values = ListParser::parse(trim($parts[1]), [';', '=']);
+            $values = ListParser::parse(trim($parts[1]), [';', '='], true);
             $length = count($values);
             $continuedValues = [];
 

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -47,7 +47,7 @@ class ContentType implements UnstructuredInterface
         $header->setType($parts[0]);
 
         if (isset($parts[1])) {
-            $values = ListParser::parse(trim($parts[1]), [';', '=']);
+            $values = ListParser::parse(trim($parts[1]), [';', '='], true);
             $length = count($values);
 
             for ($i = 0; $i < $length; $i += 2) {

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -39,6 +39,7 @@ class ContentDispositionTest extends TestCase
 
     public static function getLiteralData()
     {
+        // @codingStandardsIgnoreStart
         return [
             [
                 ['filename' => 'foo; bar.txt'],
@@ -57,6 +58,7 @@ class ContentDispositionTest extends TestCase
                 'attachment; filename*=utf-8\'\'Capture%20d%E2%80%99e%CC%81cran%202020%2D05%2D13%20a%CC%80%2017.13.47.png'
             ],
         ];
+        // @codingStandardsIgnoreEnd
     }
 
     /**

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -52,6 +52,10 @@ class ContentDispositionTest extends TestCase
                 [],
                 'inline'
             ],
+            [
+                ['filename' => 'Capture d’écran 2020-05-13 à 17.13.47.png'],
+                'attachment; filename*=utf-8\'\'Capture%20d%E2%80%99e%CC%81cran%202020%2D05%2D13%20a%CC%80%2017.13.47.png'
+            ],
         ];
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

When trying to parse an attached file having a header in a "RFC 5987 format", an exception is thrown:
```
Uncaught Exception Laminas\Mail\Header\Exception\InvalidArgumentException: Invalid header line for Content-Disposition string - incomplete continuation in /var/www/xxx/vendor/laminas/laminas-mail/src/Header/ContentDisposition.php at line 84
  Backtrace :
  vendor/laminas/laminas-mail/src/Headers.php:485    Laminas\Mail\Header\ContentDisposition::fromString()
  vendor/laminas/laminas-mail/src/Headers.php:232    Laminas\Mail\Headers->loadHeader()
  vendor/laminas/laminas-mail/src/Headers.php:96     Laminas\Mail\Headers->addHeaderLine()
  vendor/laminas/laminas-mime/src/Decode.php:150     Laminas\Mail\Headers::fromString()
  vendor/laminas/laminas-mime/src/Decode.php:81      Laminas\Mime\Decode::splitMessage()
  ...r/laminas/laminas-mail/src/Storage/Part.php:194 Laminas\Mime\Decode::splitMessageStruct()
  ...r/laminas/laminas-mail/src/Storage/Part.php:256 Laminas\Mail\Storage\Part->cacheContent()
  ...r/laminas/laminas-mail/src/Storage/Part.php:471 Laminas\Mail\Storage\Part->countParts()
  xxx/xxx.php:xxx                   Laminas\Mail\Storage\Part->rewind()
```

With this PR, this format will be handled and no exception will be triggered.

I found this exception while trying to parse an email received from an Apple Mail client. As I was not able to recreate a real case using another charset as utf-8, I was not really sure how to handle it, so I did not.