### PR TITLE
Fix issue #121: Correct return value

### DIFF
--- a/src/AddressList.php
+++ b/src/AddressList.php
@@ -96,6 +96,7 @@ class AddressList implements Countable, Iterator
     public function addFromString($address, $comment = null)
     {
         $this->add(Address::fromString($address, $comment));
+        return $this;
     }
 
     /**


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Current calls to AddressList::addFromString do not return a value, contrary to the docblock and behavior of other AddressList-modifying methods.

This returns the modified AddressList object to maintain a fluent
interface, as all the other state-modifying methods on AddressList do
(and as the docblock indicates that it should).

Fixes #121
