### PR TITLE
Fold long lines during smtp communication in Protocol\Smtp class

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -324,12 +324,18 @@ class Smtp extends AbstractProtocol
         unset($data);
         rewind($fp);
 
-        // max line length is 998 char + \r\n = 1000
-        while (($line = stream_get_line($fp, 1000, "\n")) !== false) {
+        // max SMTP line length is 998 char + \r\n = 1000
+        // read the line up to PHP_SOCK_CHUNK_SIZE
+        while (($line = stream_get_line($fp, 0, "\n")) !== false) {
             $line = rtrim($line, "\r");
             if (isset($line[0]) && $line[0] === '.') {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;
+            }
+            if (strlen($line) > 998) {
+                // Long lines are "folded" by inserting "<CR><LF><SPACE>"
+                // https://tools.ietf.org/html/rfc5322#section-2.2.3
+                $line = substr(chunk_split($line, 998, "\r\n "), 0, -3);
             }
             $this->_send($line);
         }

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -324,7 +324,7 @@ class Smtp extends AbstractProtocol
         unset($data);
         rewind($fp);
 
-        // max SMTP line length is 998 char + \r\n = 1000
+        // max line length is 998 char + \r\n = 1000
         // read the line up to PHP_SOCK_CHUNK_SIZE
         while (($line = stream_get_line($fp, 0, "\n")) !== false) {
             $line = rtrim($line, "\r");


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | ??
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

Fold long lines following RFC 5322 section-2.2.3
    
To deal with the 998/78 character limitations per line,
long lines can be split into a multiple-line representation
separated by CRLF + SPACE; this is called "folding".
Correct folding is particularly important for long header fields
(e.g. generated by MS Exchange).

@glensc adds: 
`It seems, the underlying problem of the bug is that currently, the loop reads up to 1000 bytes, and if the input is longer than that, then everything over 1000 bytes will appear as the next line in mail headers, resulting in corruption. And depending on MTA, such corruption is treated as the end of headers input.`
