### PR TITLE
Fix #25; Skip empty continuation lines

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -83,13 +83,16 @@ class Headers implements Countable, Iterator
         for ($i = 0; $i < $total; $i += 1) {
             $line = $lines[$i];
 
-            // Empty line indicates end of headers
-            // EXCEPT if there are more lines, in which case, there's a possible error condition
-            if (preg_match('/^\s*$/', $line)) {
+            if ($line === "") {
+                // Empty line indicates end of headers
+                // EXCEPT if there are more lines, in which case, there's a possible error condition
                 $emptyLine += 1;
                 if ($emptyLine > 2) {
                     throw new Exception\RuntimeException('Malformed header detected');
                 }
+                continue;
+            } elseif (preg_match('/^\s*$/', $line)) {
+                // skip empty continuation line
                 continue;
             }
 

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -156,16 +156,19 @@ class MessageTest extends TestCase
         );
     }
 
-    public function testNotAllowWhitespaceInEmptyMultiLineHeader(): void
+    public function testAllowWhitespaceInEmptyMultiLineHeader(): void
     {
         $src = "From: user@example.com\nTo: userpal@example.net\n"
             . "Subject: This is your reminder\n  \n \n"
             . "  about the football game tonight\n"
             . "Date: Wed, 20 Oct 2010 20:53:35 -0400\n\n"
             . "Don't forget to meet us for the tailgate party!\n";
-
-        $this->expectException(MailException\RuntimeException::class);
         $message = new Message(['raw' => $src]);
+
+        $this->assertEquals(
+            'This is your reminder about the football game tonight',
+            $message->getHeader('subject', 'string')
+        );
     }
 
     public function testContentTypeDecode(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The fix introduced in https://github.com/zendframework/zend-mail/pull/196 allow a single empty continuation line in the headers.

The following example will be considered as valid:
```
From: user@example.com
To: userpal@example.net
Subject: This is your reminder
[SPACE]
  about the football game tonight 
Date: Wed, 20 Oct 2010 20:53:35 -0400 
```

But not these two:
```
From: user@example.com
To: userpal@example.net
Subject: This is your reminder
[SPACE]
  about the football 
[SPACE]
  game tonight 
Date: Wed, 20 Oct 2010 20:53:35 -0400 
```

```
From: user@example.com
To: userpal@example.net
Subject: This is your reminder
[SPACE]
[SPACE]
  about the football game tonight 
Date: Wed, 20 Oct 2010 20:53:35 -0400 
```

While the [RFC](https://tools.ietf.org/html/rfc7103#section-7.3) indicate these empty continuation lines are no longer legal, it also recommend that they should just be ignored and not stop the message from being parsed:
> The best handling of this example is for a message parsing engine to behave as if line {4} 
were not present in the message

With these changes all empty continuation lines will be ignored so that the 3 example above will all be considered as valid and parsed accordingly.
