### PR TITLE
Fix #152: Use strict string comparisons for header keys

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -379,7 +379,7 @@ class Headers implements Countable, Iterator
         $key = $this->normalizeFieldName($name);
         $results = [];
 
-        foreach (array_keys($this->headersKeys, $key) as $index) {
+        foreach (array_keys($this->headersKeys, $key, true) as $index) {
             if ($this->headers[$index] instanceof Header\GenericHeader) {
                 $results[] = $this->lazyLoadHeader($index);
             } else {
@@ -409,7 +409,7 @@ class Headers implements Countable, Iterator
     public function has($name)
     {
         $name = $this->normalizeFieldName($name);
-        return in_array($name, $this->headersKeys);
+        return in_array($name, $this->headersKeys, true);
     }
 
     /**

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -640,4 +640,16 @@ class HeadersTest extends TestCase
         $headers->setHeaderLocator($locator);
         $this->assertSame($locator, $headers->getHeaderLocator());
     }
+
+    public function testStrictKeyComparisonInHas(): void
+    {
+        $headers = Mail\Headers::fromString("000: foo-bar");
+        $this->assertFalse($headers->has('0'));
+    }
+
+    public function testStrictKeyComparisonInGet(): void
+    {
+        $headers = Mail\Headers::fromString("000: foo-bar");
+        $this->assertFalse($headers->get('0'));
+    }
 }


### PR DESCRIPTION
Signed-off-by: Paul Buonopane <paul@namepros.com>

This replaces #153, which targeted the wrong branch.

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #152 by using strict string comparisons with `in_array` and `array_keys`.
