### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "laminas/laminas-stdlib": "^3.6",
         "laminas/laminas-validator": "^2.15",
         "symfony/polyfill-mbstring": "^1.12.0",
-        "true/punycode": "^2.1"
+        "true/punycode": "^2.1",
+        "webmozart/assert": "^1.10"
     },
     "conflict": {
         "zendframework/zend-mail": "*"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "ext-iconv": "*",
         "laminas/laminas-loader": "^2.8",
-        "laminas/laminas-mime": "^2.9",
+        "laminas/laminas-mime": "^2.9.1",
         "laminas/laminas-stdlib": "^3.6",
         "laminas/laminas-validator": "^2.15",
         "symfony/polyfill-mbstring": "^1.12.0",

--- a/composer.json
+++ b/composer.json
@@ -8,26 +8,24 @@
     "homepage": "https://laminas.dev",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "ext-iconv": "*",
-        "laminas/laminas-loader": "^2.5",
-        "laminas/laminas-mime": "^2.5",
-        "laminas/laminas-stdlib": "^2.7 || ^3.0",
-        "laminas/laminas-validator": "^2.10.2",
-        "laminas/laminas-zendframework-bridge": "^1.0",
+        "laminas/laminas-loader": "^2.8",
+        "laminas/laminas-mime": "^2.9",
+        "laminas/laminas-stdlib": "^3.6",
+        "laminas/laminas-validator": "^2.15",
         "symfony/polyfill-mbstring": "^1.12.0",
         "true/punycode": "^2.1"
     },
-    "replace": {
-        "zendframework/zend-mail": "^2.10.0"
+    "conflict": {
+        "zendframework/zend-mail": "*"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-config": "^3.4",
-        "laminas/laminas-crypt": "^2.6 || ^3.0",
-        "laminas/laminas-db": "^2.12",
-        "laminas/laminas-servicemanager": "^3.2.1",
-        "phpunit/phpunit": "^9.3",
+        "laminas/laminas-crypt": "^2.6 || ^3.4",
+        "laminas/laminas-db": "^2.13.3",
+        "laminas/laminas-servicemanager": "^3.7",
+        "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.15.1",
         "vimeo/psalm": "^4.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1751ed01fdfb21a06d88922f339a72c2",
+    "content-hash": "1a7c0799aa0d9458ce5b1e553f90fc4e",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -100,16 +100,16 @@
         },
         {
             "name": "laminas/laminas-mime",
-            "version": "2.9.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mime.git",
-                "reference": "02cc861f704d468726866457dcf8338d1fe74e76"
+                "reference": "72d21a1b4bb7086d4a4d7058c0abca180b209184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mime/zipball/02cc861f704d468726866457dcf8338d1fe74e76",
-                "reference": "02cc861f704d468726866457dcf8338d1fe74e76",
+                "url": "https://api.github.com/repos/laminas/laminas-mime/zipball/72d21a1b4bb7086d4a4d7058c0abca180b209184",
+                "reference": "72d21a1b4bb7086d4a4d7058c0abca180b209184",
                 "shasum": ""
             },
             "require": {
@@ -157,7 +157,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-03T02:18:35+00:00"
+            "time": "2021-09-20T21:19:24+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "246b0828dc516697fa069371942f97aa",
+    "content-hash": "1751ed01fdfb21a06d88922f339a72c2",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -357,6 +357,85 @@
             "time": "2021-03-05T17:36:06+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.23.1",
             "source": {
@@ -485,6 +564,64 @@
                 "source": "https://github.com/true/php-punycode/tree/master"
             },
             "time": "2016-11-16T10:37:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "packages-dev": [
@@ -3775,85 +3912,6 @@
             "time": "2021-03-23T23:28:01+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-02-19T12:13:01+00:00"
-        },
-        {
             "name": "symfony/polyfill-intl-grapheme",
             "version": "v1.23.1",
             "source": {
@@ -4496,64 +4554,6 @@
                 "source": "https://github.com/vimeo/psalm/tree/4.10.0"
             },
             "time": "2021-09-04T21:00:09+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
-            },
-            "time": "2021-03-09T10:59:23+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b14fcb4dec0f401b353b8b0f971f2597",
+    "content-hash": "246b0828dc516697fa069371942f97aa",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -307,68 +307,6 @@
                 }
             ],
             "time": "2021-09-08T23:16:56+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "psr/container",
@@ -1184,75 +1122,6 @@
             "time": "2019-12-31T16:28:26+00:00"
         },
         {
-            "name": "laminas/laminas-config",
-            "version": "3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "2f2273a6bdf966a9adf6042f8950b6c33199a3b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/2f2273a6bdf966a9adf6042f8950b6c33199a3b7",
-                "reference": "2f2273a6bdf966a9adf6042f8950b6c33199a3b7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
-                "php": "^7.3 || ~8.0.0",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "container-interop/container-interop": "<1.2.0",
-                "zendframework/zend-config": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-filter": "^2.7.2",
-                "laminas/laminas-i18n": "^2.10.3",
-                "laminas/laminas-servicemanager": "^3.4.1",
-                "malukenho/docheader": "^0.1.6",
-                "phpunit/phpunit": "^8.5.8"
-            },
-            "suggest": {
-                "laminas/laminas-filter": "^2.7.2; install if you want to use the Filter processor",
-                "laminas/laminas-i18n": "^2.7.4; install if you want to use the Translator processor",
-                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3; if you need an extensible plugin manager for use with the Config Factory"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Config\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "config",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-config/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-config/issues",
-                "rss": "https://github.com/laminas/laminas-config/releases.atom",
-                "source": "https://github.com/laminas/laminas-config"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-08T09:58:39+00:00"
-        },
-        {
             "name": "laminas/laminas-crypt",
             "version": "3.4.0",
             "source": {
@@ -1543,6 +1412,68 @@
                 }
             ],
             "time": "2021-07-24T19:33:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4681,7 +4612,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "ext-iconv": "*"
     },
     "platform-dev": [],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1046,14 +1046,10 @@
       <code>buildFolderTree</code>
       <code>selectFolder</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>! empty($params-&gt;folder) ? $params-&gt;folder : 'INBOX'</code>
-      <code>$params-&gt;dirname</code>
-      <code>$params-&gt;dirname</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="3">
       <code>$currentFolder</code>
-      <code>$this-&gt;delim</code>
+      <code>$delim</code>
+      <code>$folder</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>\Laminas\Mail\Storage\Folder</code>
@@ -1061,11 +1057,8 @@
     <MixedMethodCall occurrences="1">
       <code>getGlobalName</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="4">
+    <MixedPropertyFetch occurrences="1">
       <code>$currentFolder-&gt;$entry</code>
-      <code>$params-&gt;delim</code>
-      <code>$params-&gt;dirname</code>
-      <code>$params-&gt;folder</code>
     </MixedPropertyFetch>
     <MixedReturnStatement occurrences="1">
       <code>$currentFolder</code>
@@ -1105,13 +1098,9 @@
       <code>buildFolderTree</code>
       <code>selectFolder</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>! empty($params-&gt;folder) ? $params-&gt;folder : 'INBOX'</code>
-      <code>$params-&gt;dirname</code>
-      <code>$params-&gt;dirname</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment occurrences="2">
       <code>$currentFolder</code>
+      <code>$folder</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>Storage\Folder</code>
@@ -1119,11 +1108,8 @@
     <MixedMethodCall occurrences="1">
       <code>getGlobalName</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="4">
+    <MixedPropertyFetch occurrences="1">
       <code>$currentFolder-&gt;$entry</code>
-      <code>$params-&gt;dirname</code>
-      <code>$params-&gt;filename</code>
-      <code>$params-&gt;folder</code>
     </MixedPropertyFetch>
     <MixedReturnStatement occurrences="1">
       <code>$currentFolder</code>
@@ -1186,16 +1172,10 @@
       <code>selectFolder</code>
       <code>setFlags</code>
     </MissingReturnType>
-    <MixedArgument occurrences="9">
+    <MixedArgument occurrences="3">
       <code>$data['delim']</code>
       <code>$data['flags']</code>
       <code>$flag</code>
-      <code>$host</code>
-      <code>$params-&gt;user</code>
-      <code>$password</code>
-      <code>$port</code>
-      <code>$ssl</code>
-      <code>isset($params-&gt;folder) ? $params-&gt;folder : 'INBOX'</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="5">
       <code>$globalName</code>
@@ -1214,11 +1194,12 @@
       <code>static::$knownFlags[$flag]</code>
       <code>static::$searchFlags[$flag]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment occurrences="13">
       <code>$data</code>
       <code>$flag</code>
       <code>$flag</code>
       <code>$flags[]</code>
+      <code>$folder</code>
       <code>$header</code>
       <code>$host</code>
       <code>$params[]</code>
@@ -1319,14 +1300,11 @@
       <code>openMaildir</code>
       <code>removeMessage</code>
     </MissingReturnType>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="4">
       <code>$a['filename']</code>
       <code>$b['filename']</code>
       <code>$data['filename']</code>
       <code>$filedata['filename']</code>
-      <code>$params-&gt;dirname</code>
-      <code>$params-&gt;dirname</code>
-      <code>$params-&gt;dirname</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="7">
       <code>$a['filename']</code>
@@ -1354,9 +1332,6 @@
       <code>int|array</code>
       <code>string|array</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="1">
-      <code>$params-&gt;dirname</code>
-    </MixedPropertyFetch>
     <MixedReturnStatement occurrences="3">
       <code>$filedata['size'] ?? filesize($filedata['filename'])</code>
       <code>$this-&gt;files[$id - 1]</code>
@@ -1426,12 +1401,11 @@
       <code>openMboxFile</code>
       <code>removeMessage</code>
     </MissingReturnType>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$messagePos['end'] - $messagePos['separator']</code>
       <code>$messagePos['separator']</code>
       <code>$messagePos['separator'] - $messagePos['start']</code>
       <code>$messagePos['start']</code>
-      <code>$params-&gt;filename</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="4">
       <code>$pos['end']</code>
@@ -1454,10 +1428,6 @@
       <code>$pos['end']</code>
       <code>$pos['end']</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="2">
-      <code>$params-&gt;filename</code>
-      <code>$params-&gt;messageEOL</code>
-    </MixedPropertyFetch>
     <MixedReturnStatement occurrences="2">
       <code>$pos['end'] - $pos['start']</code>
       <code>$this-&gt;positions[$id - 1]</code>
@@ -1692,13 +1662,6 @@
       <code>noop</code>
       <code>removeMessage</code>
     </MissingReturnType>
-    <MixedArgument occurrences="5">
-      <code>$host</code>
-      <code>$params-&gt;user</code>
-      <code>$password</code>
-      <code>$port</code>
-      <code>$ssl</code>
-    </MixedArgument>
     <MixedAssignment occurrences="5">
       <code>$host</code>
       <code>$password</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -18,6 +18,7 @@
         <InternalMethod>
             <errorLevel type="suppress">
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+                <referencedMethod name="Laminas\Mail\Storage\ParamsNormalizer::normalizeParams"/>
             </errorLevel>
             <errorLevel type="suppress">
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
@@ -26,7 +27,14 @@
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
             </errorLevel>
         </InternalMethod>
+
+        <InternalClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Laminas\Mail\Storage\ParamsNormalizer"/>
+            </errorLevel>
+        </InternalClass>
     </issueHandlers>
+
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>

--- a/src/AddressList.php
+++ b/src/AddressList.php
@@ -4,6 +4,7 @@ namespace Laminas\Mail;
 
 use Countable;
 use Iterator;
+use ReturnTypeWillChange;
 
 class AddressList implements Countable, Iterator
 {
@@ -157,6 +158,7 @@ class AddressList implements Countable, Iterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->addresses);
@@ -169,6 +171,7 @@ class AddressList implements Countable, Iterator
      * empty.
      * @see addresses
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->addresses);
@@ -179,6 +182,7 @@ class AddressList implements Countable, Iterator
      *
      * @return Address
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->addresses);
@@ -189,6 +193,7 @@ class AddressList implements Countable, Iterator
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->addresses);
@@ -201,6 +206,7 @@ class AddressList implements Countable, Iterator
      * internal array pointer, or false if there are no more elements.
      * @see addresses
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->addresses);
@@ -211,6 +217,7 @@ class AddressList implements Countable, Iterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $key = key($this->addresses);

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -5,6 +5,8 @@ namespace Laminas\Mail\Header;
 use Laminas\Mail\Address;
 use Laminas\Mail\AddressList;
 use Laminas\Mail\Headers;
+use Laminas\Mail\Storage\Exception\RuntimeException;
+use Throwable;
 use TrueBV\Exception\OutOfBoundsException;
 use TrueBV\Punycode;
 
@@ -13,6 +15,22 @@ use TrueBV\Punycode;
  */
 abstract class AbstractAddressList implements HeaderInterface
 {
+    private const IDNA_ERROR_MAP = [
+        IDNA_ERROR_EMPTY_LABEL => 'empty label',
+        IDNA_ERROR_LABEL_TOO_LONG => 'label too long',
+        IDNA_ERROR_DOMAIN_NAME_TOO_LONG => 'domain name too long',
+        IDNA_ERROR_LEADING_HYPHEN => 'leading hyphen',
+        IDNA_ERROR_TRAILING_HYPHEN => 'trailing hyphen',
+        IDNA_ERROR_HYPHEN_3_4 => 'consecutive hyphens',
+        IDNA_ERROR_LEADING_COMBINING_MARK => 'leading combining mark',
+        IDNA_ERROR_DISALLOWED => 'disallowed',
+        IDNA_ERROR_PUNYCODE => 'invalid punycode encoding',
+        IDNA_ERROR_LABEL_HAS_DOT => 'has dot',
+        IDNA_ERROR_INVALID_ACE_LABEL => 'label not in ASCII encoding',
+        IDNA_ERROR_BIDI => 'fails bidirectional criteria',
+        IDNA_ERROR_CONTEXTJ => 'one or more characters fail CONTEXTJ rule',
+    ];
+
     /**
      * @var AddressList
      */
@@ -110,14 +128,11 @@ abstract class AbstractAddressList implements HeaderInterface
      */
     protected function idnToAscii($domainName)
     {
-        if (null === self::$punycode) {
-            self::$punycode = new Punycode();
+        if (function_exists('idn_to_ascii')) {
+            return $this->idnToAsciiViaIntl($domainName);
         }
-        try {
-            return self::$punycode->encode($domainName);
-        } catch (OutOfBoundsException $e) {
-            return $domainName;
-        }
+
+        return $this->idnToAsciiViaPunycode($domainName);
     }
 
     public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
@@ -251,5 +266,41 @@ abstract class AbstractAddressList implements HeaderInterface
             '',
             $value
         );
+    }
+
+    private function idnToAsciiViaIntl(string $domainName): string
+    {
+        $ascii = idn_to_ascii($domainName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, $conversionInfo);
+        if (false !== $ascii) {
+            return $ascii;
+        }
+
+        $messages = [];
+        $errors   = (int) $conversionInfo['errors'];
+
+        foreach (self::IDNA_ERROR_MAP as $flag => $message) {
+            if (($flag & $errors) === $flag) {
+                $messages[] = $message;
+            }
+        }
+
+        throw new RuntimeException(sprintf(
+            'Failed encoding domain due to errors: %s',
+            implode(', ', $messages)
+        ));
+    }
+
+    private function idnToAsciiViaPunycode(string $domainName): string
+    {
+        if (null === self::$punycode) {
+            self::$punycode = new Punycode();
+        }
+        try {
+            return self::$punycode->encode($domainName);
+        } catch (OutOfBoundsException $e) {
+            return $domainName;
+        } catch (Throwable $e) {
+            throw new RuntimeException(sprintf('Unable to convert IDN to ASCII: %s', $e->getMessage()));
+        }
     }
 }

--- a/src/Header/GenericHeader.php
+++ b/src/Header/GenericHeader.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Mail\Header;
 
+use Laminas\Mail\Header\Exception\InvalidArgumentException;
 use Laminas\Mime\Mime;
 
 class GenericHeader implements HeaderInterface, UnstructuredInterface
@@ -9,12 +10,12 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
     /**
      * @var string
      */
-    protected $fieldName = null;
+    protected $fieldName;
 
     /**
      * @var string
      */
-    protected $fieldValue = null;
+    protected $fieldValue = '';
 
     /**
      * Header encoding
@@ -67,13 +68,15 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
      * Constructor
      *
      * @param string $fieldName  Optional
-     * @param string $fieldValue Optional
+     * @param null|string $fieldValue Optional
      */
     public function __construct($fieldName = null, $fieldValue = null)
     {
-        if ($fieldName) {
-            $this->setFieldName($fieldName);
+        if (! $fieldName) {
+            throw new InvalidArgumentException('Header MUST contain a field name');
         }
+
+        $this->setFieldName($fieldName);
 
         if ($fieldValue !== null) {
             $this->setFieldValue($fieldValue);

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -10,6 +10,7 @@ use Iterator;
 use Laminas\Loader\PluginClassLocator;
 use Laminas\Mail\Header\GenericHeader;
 use Laminas\Mail\Header\HeaderInterface;
+use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -410,6 +411,7 @@ class Headers implements Countable, Iterator
      * Advance the pointer for this object as an iterator
      *
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->headers);
@@ -420,6 +422,7 @@ class Headers implements Countable, Iterator
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->headers);
@@ -430,6 +433,7 @@ class Headers implements Countable, Iterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (current($this->headers) !== false);
@@ -439,6 +443,7 @@ class Headers implements Countable, Iterator
      * Reset the internal pointer for this object as an iterator
      *
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->headers);
@@ -449,6 +454,7 @@ class Headers implements Countable, Iterator
      *
      * @return Header\HeaderInterface
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $current = current($this->headers);
@@ -464,6 +470,7 @@ class Headers implements Countable, Iterator
      *
      * @return int count of currently known headers
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->headers);

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -4,6 +4,7 @@ namespace Laminas\Mail\Storage;
 
 use ArrayAccess;
 use Countable;
+use ReturnTypeWillChange;
 use SeekableIterator;
 
 abstract class AbstractStorage implements
@@ -182,6 +183,7 @@ abstract class AbstractStorage implements
      *
      * @return   int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->countMessages();
@@ -193,6 +195,7 @@ abstract class AbstractStorage implements
      * @param  int  $id
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($id)
     {
         try {
@@ -211,6 +214,7 @@ abstract class AbstractStorage implements
      * @param    int $id
      * @return   \Laminas\Mail\Storage\Message message object
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($id)
     {
         return $this->getMessage($id);
@@ -223,6 +227,7 @@ abstract class AbstractStorage implements
      * @param mixed $value
      * @throws Exception\RuntimeException
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($id, $value)
     {
         throw new Exception\RuntimeException('cannot write mail messages via array access');
@@ -234,6 +239,7 @@ abstract class AbstractStorage implements
      * @param    int   $id
      * @return   bool success
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($id)
     {
         return $this->removeMessage($id);
@@ -246,6 +252,7 @@ abstract class AbstractStorage implements
      * the interfaces and your scripts take long you should use reset()
      * from time to time.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iterationMax = $this->countMessages();
@@ -257,6 +264,7 @@ abstract class AbstractStorage implements
      *
      * @return Message current message
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->getMessage($this->iterationPos);
@@ -267,6 +275,7 @@ abstract class AbstractStorage implements
      *
      * @return   int id of current position
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iterationPos;
@@ -275,6 +284,7 @@ abstract class AbstractStorage implements
     /**
      * Iterator::next()
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->iterationPos;
@@ -285,6 +295,7 @@ abstract class AbstractStorage implements
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         if ($this->iterationMax === null) {
@@ -299,6 +310,7 @@ abstract class AbstractStorage implements
      * @param  int $pos
      * @throws Exception\OutOfBoundsException
      */
+    #[ReturnTypeWillChange]
     public function seek($pos)
     {
         if ($this->iterationMax === null) {

--- a/src/Storage/Folder.php
+++ b/src/Storage/Folder.php
@@ -3,6 +3,7 @@
 namespace Laminas\Mail\Storage;
 
 use RecursiveIterator;
+use ReturnTypeWillChange;
 
 class Folder implements RecursiveIterator
 {
@@ -52,6 +53,7 @@ class Folder implements RecursiveIterator
      *
      * @return bool current element has children
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         $current = $this->current();
@@ -63,6 +65,7 @@ class Folder implements RecursiveIterator
      *
      * @return \Laminas\Mail\Storage\Folder same as self::current()
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return $this->current();
@@ -73,6 +76,7 @@ class Folder implements RecursiveIterator
      *
      * @return bool check if there's a current element
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return key($this->folders) !== null;
@@ -81,6 +85,7 @@ class Folder implements RecursiveIterator
     /**
      * implements Iterator::next()
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->folders);
@@ -91,6 +96,7 @@ class Folder implements RecursiveIterator
      *
      * @return string key/local name of current element
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->folders);
@@ -101,6 +107,7 @@ class Folder implements RecursiveIterator
      *
      * @return \Laminas\Mail\Storage\Folder current folder
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->folders);
@@ -109,6 +116,7 @@ class Folder implements RecursiveIterator
     /**
      * implements Iterator::rewind()
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->folders);

--- a/src/Storage/Folder/Maildir.php
+++ b/src/Storage/Folder/Maildir.php
@@ -157,10 +157,15 @@ class Maildir extends Storage\Maildir implements FolderInterface
         $subname = trim($rootFolder, $this->delim);
 
         while ($currentFolder) {
-            ErrorHandler::start(E_NOTICE);
-            list($entry, $subname) = explode($this->delim, $subname, 2);
-            ErrorHandler::stop();
+            if (false !== strpos($subname, $this->delim)) {
+                list($entry, $subname) = explode($this->delim, $subname, 2);
+            } else {
+                $entry   = $subname;
+                $subname = null;
+            }
+
             $currentFolder = $currentFolder->$entry;
+
             if (! $subname) {
                 break;
             }

--- a/src/Storage/Folder/Maildir.php
+++ b/src/Storage/Folder/Maildir.php
@@ -4,13 +4,11 @@ namespace Laminas\Mail\Storage\Folder;
 
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
-use Laminas\Mail\Storage\ParamsNormalizerTrait;
+use Laminas\Mail\Storage\ParamsNormalizer;
 use Laminas\Stdlib\ErrorHandler;
 
 class Maildir extends Storage\Maildir implements FolderInterface
 {
-    use ParamsNormalizerTrait;
-
     /**
      * root folder for folder structure
      * @var Storage\Folder
@@ -49,7 +47,7 @@ class Maildir extends Storage\Maildir implements FolderInterface
      */
     public function __construct($params)
     {
-        $params = $this->normalizeParams($params);
+        $params = ParamsNormalizer::normalizeParams($params);
 
         if (! isset($params['dirname'])) {
             throw new Exception\InvalidArgumentException('no dirname provided in params');

--- a/src/Storage/Folder/Mbox.php
+++ b/src/Storage/Folder/Mbox.php
@@ -131,10 +131,15 @@ class Mbox extends Storage\Mbox implements FolderInterface
         $currentFolder = $this->rootFolder;
         $subname = trim($rootFolder, DIRECTORY_SEPARATOR);
         while ($currentFolder) {
-            ErrorHandler::start(E_NOTICE | E_WARNING);
-            list($entry, $subname) = explode(DIRECTORY_SEPARATOR, $subname, 2);
-            ErrorHandler::stop();
+            if (false !== strpos($subname, DIRECTORY_SEPARATOR)) {
+                list($entry, $subname) = explode(DIRECTORY_SEPARATOR, $subname, 2);
+            } else {
+                $entry   = $subname;
+                $subname = null;
+            }
+
             $currentFolder = $currentFolder->$entry;
+
             if (! $subname) {
                 break;
             }

--- a/src/Storage/Folder/Mbox.php
+++ b/src/Storage/Folder/Mbox.php
@@ -133,7 +133,7 @@ class Mbox extends Storage\Mbox implements FolderInterface
         $currentFolder = $this->rootFolder;
         $subname = trim($rootFolder, DIRECTORY_SEPARATOR);
         while ($currentFolder) {
-            ErrorHandler::start(E_NOTICE);
+            ErrorHandler::start(E_NOTICE | E_WARNING);
             list($entry, $subname) = explode(DIRECTORY_SEPARATOR, $subname, 2);
             ErrorHandler::stop();
             $currentFolder = $currentFolder->$entry;

--- a/src/Storage/Folder/Mbox.php
+++ b/src/Storage/Folder/Mbox.php
@@ -4,13 +4,11 @@ namespace Laminas\Mail\Storage\Folder;
 
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
-use Laminas\Mail\Storage\ParamsNormalizerTrait;
+use Laminas\Mail\Storage\ParamsNormalizer;
 use Laminas\Stdlib\ErrorHandler;
 
 class Mbox extends Storage\Mbox implements FolderInterface
 {
-    use ParamsNormalizerTrait;
-
     /**
      * Storage\Folder root folder for folder structure
      * @var Storage\Folder
@@ -46,7 +44,7 @@ class Mbox extends Storage\Mbox implements FolderInterface
      */
     public function __construct($params)
     {
-        $params = $this->normalizeParams($params);
+        $params = ParamsNormalizer::normalizeParams($params);
 
         if (isset($params['filename'])) {
             throw new Exception\InvalidArgumentException(sprintf('use %s for a single file', Storage\Mbox::class));

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -7,8 +7,6 @@ use Laminas\Mail\Protocol;
 
 class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\WritableInterface
 {
-    use ParamsNormalizerTrait;
-
     // TODO: with an internal cache we could optimize this class, or create an extra class with
     // such optimizations. Especially the various fetch calls could be combined to one cache call
 
@@ -196,7 +194,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
             return;
         }
 
-        $params = $this->normalizeParams($params);
+        $params = ParamsNormalizer::normalizeParams($params);
 
         if (! isset($params['user'])) {
             throw new Exception\InvalidArgumentException('need at least user in params');

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -299,21 +299,35 @@ class Maildir extends AbstractStorage
                 continue;
             }
 
-            ErrorHandler::start(E_NOTICE | E_WARNING);
-            list($uniq, $info) = explode(':', $entry, 2);
-            list(, $size) = explode(',', $uniq, 2);
-            ErrorHandler::stop();
-            if ($size && $size[0] == 'S' && $size[1] == '=') {
+            if (false !== strpos($entry, ':')) {
+                list($uniq, $info) = explode(':', $entry, 2);
+            } else {
+                $uniq = $entry;
+                $info = '';
+            }
+
+            if (false !== strpos($uniq, ',')) {
+                list(, $size) = explode(',', $uniq, 2);
+            } else {
+                $size = '';
+            }
+
+            if (strlen($size) >= 2 && $size[0] === 'S' && $size[1] === '=') {
                 $size = substr($size, 2);
             }
-            if (is_string($size) && ! ctype_digit($size)) {
+
+            if (! ctype_digit($size)) {
                 $size = null;
             }
 
-            ErrorHandler::start(E_NOTICE);
-            list($version, $flags) = explode(',', $info ?? '', 2);
-            ErrorHandler::stop();
-            if ($version != 2) {
+            if (false !== strpos($info, ',')) {
+                list($version, $flags) = explode(',', $info, 2);
+            } else {
+                $version = $info;
+                $flags   = '';
+            }
+
+            if ($version !== '2') {
                 $flags = '';
             }
 
@@ -335,7 +349,8 @@ class Maildir extends AbstractStorage
             }
             $this->files[] = $data;
         }
-        \usort($this->files, function ($a, $b) {
+
+        \usort($this->files, function ($a, $b): int {
             return \strcmp($a['filename'], $b['filename']);
         });
     }

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -301,7 +301,7 @@ class Maildir extends AbstractStorage
                 continue;
             }
 
-            ErrorHandler::start(E_NOTICE);
+            ErrorHandler::start(E_NOTICE | E_WARNING);
             list($uniq, $info) = explode(':', $entry, 2);
             list(, $size) = explode(',', $uniq, 2);
             ErrorHandler::stop();

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -313,7 +313,7 @@ class Maildir extends AbstractStorage
             }
 
             ErrorHandler::start(E_NOTICE);
-            list($version, $flags) = explode(',', $info, 2);
+            list($version, $flags) = explode(',', $info ?? '', 2);
             ErrorHandler::stop();
             if ($version != 2) {
                 $flags = '';

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -308,7 +308,7 @@ class Maildir extends AbstractStorage
             if ($size && $size[0] == 'S' && $size[1] == '=') {
                 $size = substr($size, 2);
             }
-            if (! ctype_digit($size)) {
+            if (is_string($size) && ! ctype_digit($size)) {
                 $size = null;
             }
 

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -2,12 +2,13 @@
 
 namespace Laminas\Mail\Storage;
 
-use Laminas\Config\Config;
 use Laminas\Mail;
 use Laminas\Stdlib\ErrorHandler;
 
 class Maildir extends AbstractStorage
 {
+    use ParamsNormalizerTrait;
+
     /**
      * used message class, change it in an extended class to extend the returned message class
      * @var string
@@ -210,26 +211,31 @@ class Maildir extends AbstractStorage
      * Supported parameters are:
      *   - dirname dirname of mbox file
      *
-     * @param  $params array|object|Config mail reader specific parameters
+     * @param $params array|object Array, iterable object, or stdClass object
+     *     with reader specific parameters
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($params)
     {
-        if (is_array($params)) {
-            $params = (object) $params;
+        $params = $this->normalizeParams($params);
+
+        if (! isset($params['dirname'])) {
+            throw new Exception\InvalidArgumentException('no dirname provided in params');
         }
 
-        if (! isset($params->dirname) || ! is_dir($params->dirname)) {
-            throw new Exception\InvalidArgumentException('no valid dirname given in params');
+        $dirname = (string) $params['dirname'] ;
+
+        if (! is_dir($dirname)) {
+            throw new Exception\InvalidArgumentException(sprintf('Maildir "%s" is not a directory', $dirname));
         }
 
-        if (! $this->isMaildir($params->dirname)) {
+        if (! $this->isMaildir($dirname)) {
             throw new Exception\InvalidArgumentException('invalid maildir given');
         }
 
         $this->has['top'] = true;
         $this->has['flags'] = true;
-        $this->openMaildir($params->dirname);
+        $this->openMaildir($dirname);
     }
 
     /**

--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -7,8 +7,6 @@ use Laminas\Stdlib\ErrorHandler;
 
 class Maildir extends AbstractStorage
 {
-    use ParamsNormalizerTrait;
-
     /**
      * used message class, change it in an extended class to extend the returned message class
      * @var string
@@ -217,7 +215,7 @@ class Maildir extends AbstractStorage
      */
     public function __construct($params)
     {
-        $params = $this->normalizeParams($params);
+        $params = ParamsNormalizer::normalizeParams($params);
 
         if (! isset($params['dirname'])) {
             throw new Exception\InvalidArgumentException('no dirname provided in params');

--- a/src/Storage/Mbox.php
+++ b/src/Storage/Mbox.php
@@ -6,8 +6,6 @@ use Laminas\Stdlib\ErrorHandler;
 
 class Mbox extends AbstractStorage
 {
-    use ParamsNormalizerTrait;
-
     /**
      * file handle to mbox file
      * @var null|resource
@@ -190,7 +188,7 @@ class Mbox extends AbstractStorage
      */
     public function __construct($params)
     {
-        $params = $this->normalizeParams($params);
+        $params = ParamsNormalizer::normalizeParams($params);
 
         if (! isset($params['filename'])) {
             throw new Exception\InvalidArgumentException('no valid filename given in params');

--- a/src/Storage/Mbox.php
+++ b/src/Storage/Mbox.php
@@ -2,11 +2,12 @@
 
 namespace Laminas\Mail\Storage;
 
-use Laminas\Config\Config;
 use Laminas\Stdlib\ErrorHandler;
 
 class Mbox extends AbstractStorage
 {
+    use ParamsNormalizerTrait;
+
     /**
      * file handle to mbox file
      * @var null|resource
@@ -189,19 +190,17 @@ class Mbox extends AbstractStorage
      */
     public function __construct($params)
     {
-        if (is_array($params)) {
-            $params = (object) $params;
-        }
+        $params = $this->normalizeParams($params);
 
-        if (! isset($params->filename)) {
+        if (! isset($params['filename'])) {
             throw new Exception\InvalidArgumentException('no valid filename given in params');
         }
 
-        if (isset($params->messageEOL)) {
-            $this->messageEOL = (string) $params->messageEOL;
+        if (isset($params['messageEOL'])) {
+            $this->messageEOL = (string) $params['messageEOL'];
         }
 
-        $this->openMboxFile($params->filename);
+        $this->openMboxFile((string) $params['filename']);
         $this->has['top']      = true;
         $this->has['uniqueid'] = false;
     }

--- a/src/Storage/ParamsNormalizer.php
+++ b/src/Storage/ParamsNormalizer.php
@@ -5,13 +5,16 @@ namespace Laminas\Mail\Storage;
 use Traversable;
 use Webmozart\Assert\Assert;
 
-trait ParamsNormalizerTrait
+/**
+ * @internal
+ */
+final class ParamsNormalizer
 {
     /**
      * @param mixed $params
      * @return array<string, mixed>
      */
-    private function normalizeParams($params): array
+    public static function normalizeParams($params): array
     {
         if ($params instanceof Traversable) {
             $params = iterator_to_array($params);

--- a/src/Storage/ParamsNormalizerTrait.php
+++ b/src/Storage/ParamsNormalizerTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laminas\Mail\Storage;
+
+use Traversable;
+use Webmozart\Assert\Assert;
+
+trait ParamsNormalizerTrait
+{
+    /**
+     * @param mixed $params
+     * @return array<string, mixed>
+     */
+    private function normalizeParams($params): array
+    {
+        if ($params instanceof Traversable) {
+            $params = iterator_to_array($params);
+        }
+
+        if (is_object($params)) {
+            $params = get_object_vars($params);
+        }
+
+        if (! is_array($params)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid $params provided; expected array|Traversable|object, received %s',
+                gettype($params)
+            ));
+        }
+
+        Assert::isMap($params, 'Expected $params to have only string keys');
+        return $params;
+    }
+}

--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -6,6 +6,7 @@ use Laminas\Mail\Header\HeaderInterface;
 use Laminas\Mail\Headers;
 use Laminas\Mime;
 use RecursiveIterator;
+use ReturnTypeWillChange;
 
 class Part implements RecursiveIterator, Part\PartInterface
 {
@@ -398,6 +399,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      *
      * @return bool current element has children/is multipart
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         $current = $this->current();
@@ -409,6 +411,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      *
      * @return Part same as self::current()
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return $this->current();
@@ -419,6 +422,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      *
      * @return bool check if there's a current element
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         if ($this->countParts === null) {
@@ -430,6 +434,7 @@ class Part implements RecursiveIterator, Part\PartInterface
     /**
      * implements Iterator::next()
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->iterationPos;
@@ -440,6 +445,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      *
      * @return string key/number of current part
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iterationPos;
@@ -450,6 +456,7 @@ class Part implements RecursiveIterator, Part\PartInterface
      *
      * @return Part current part
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->getPart($this->iterationPos);
@@ -458,6 +465,7 @@ class Part implements RecursiveIterator, Part\PartInterface
     /**
      * implements Iterator::rewind()
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->countParts();

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -8,8 +8,6 @@ use Laminas\Mime;
 
 class Pop3 extends AbstractStorage
 {
-    use ParamsNormalizerTrait;
-
     /**
      * protocol handler
      * @var null|\Laminas\Mail\Protocol\Pop3
@@ -133,7 +131,7 @@ class Pop3 extends AbstractStorage
             return;
         }
 
-        $params = $this->normalizeParams($params);
+        $params = ParamsNormalizer::normalizeParams($params);
 
         if (! isset($params['user'])) {
             throw new Exception\InvalidArgumentException('need at least user in params');

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -2,13 +2,14 @@
 
 namespace Laminas\Mail\Storage;
 
-use Laminas\Config\Config;
 use Laminas\Mail\Exception as MailException;
 use Laminas\Mail\Protocol;
 use Laminas\Mime;
 
 class Pop3 extends AbstractStorage
 {
+    use ParamsNormalizerTrait;
+
     /**
      * protocol handler
      * @var null|\Laminas\Mail\Protocol\Pop3
@@ -116,17 +117,13 @@ class Pop3 extends AbstractStorage
      *   - port port for POP3 server [optional, default = 110]
      *   - ssl 'SSL' or 'TLS' for secure sockets
      *
-     * @param  array|object|Config|Protocol\Pop3 $params mail reader specific
+     * @param  array|object|Protocol\Pop3 $params mail reader specific
      *     parameters or configured Pop3 protocol object
      * @throws \Laminas\Mail\Storage\Exception\InvalidArgumentException
      * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
      */
     public function __construct($params)
     {
-        if (is_array($params)) {
-            $params = (object) $params;
-        }
-
         $this->has['fetchPart'] = false;
         $this->has['top']       = null;
         $this->has['uniqueid']  = null;
@@ -136,23 +133,33 @@ class Pop3 extends AbstractStorage
             return;
         }
 
-        if (! isset($params->user)) {
+        $params = $this->normalizeParams($params);
+
+        if (! isset($params['user'])) {
             throw new Exception\InvalidArgumentException('need at least user in params');
         }
 
-        $host     = isset($params->host) ? $params->host : 'localhost';
-        $password = isset($params->password) ? $params->password : '';
-        $port     = isset($params->port) ? $params->port : null;
-        $ssl      = isset($params->ssl) ? $params->ssl : false;
+        $host     = $params['host'] ?? 'localhost';
+        $password = $params['password'] ?? '';
+        $port     = $params['port'] ?? null;
+        $ssl      = $params['ssl'] ?? false;
+
+        if (null !== $port) {
+            $port = (int) $port;
+        }
+
+        if (! is_string($ssl)) {
+            $ssl = (bool) $ssl;
+        }
 
         $this->protocol = new Protocol\Pop3();
 
-        if (isset($params->novalidatecert)) {
-            $this->protocol->setNoValidateCert((bool)$params->novalidatecert);
+        if (array_key_exists('novalidatecert', $params)) {
+            $this->protocol->setNoValidateCert((bool) $params['novalidatecert']);
         }
 
-        $this->protocol->connect($host, $port, $ssl);
-        $this->protocol->login($params->user, $password);
+        $this->protocol->connect((string) $host, $port, $ssl);
+        $this->protocol->login((string) $params['user'], (string) $password);
     }
 
     /**

--- a/test/Header/GenericHeaderTest.php
+++ b/test/Header/GenericHeaderTest.php
@@ -3,6 +3,7 @@
 namespace LaminasTest\Mail\Header;
 
 use Laminas\Mail\Header\Exception;
+use Laminas\Mail\Header\Exception\InvalidArgumentException;
 use Laminas\Mail\Header\GenericHeader;
 use PHPUnit\Framework\TestCase;
 
@@ -52,12 +53,27 @@ class GenericHeaderTest extends TestCase
     /**
      * @dataProvider fieldNames
      * @group ZF2015-04
+     * @param mixed $fieldName
      */
-    public function testRaisesExceptionOnInvalidFieldName($fieldName): void
+    public function testConstructorRaisesExceptionOnInvalidFieldName($fieldName): void
     {
-        $header = new GenericHeader();
-        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('name');
+        /** @psalm-suppress MixedArgument */
+        new GenericHeader($fieldName);
+    }
+
+    /**
+     * @dataProvider fieldNames
+     * @group ZF2015-04
+     * @param mixed $fieldName
+     */
+    public function testSetFieldNameRaisesExceptionOnInvalidFieldName($fieldName): void
+    {
+        $header = new GenericHeader('Subject');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('name');
+        /** @psalm-suppress MixedArgument */
         $header->setFieldName($fieldName);
     }
 
@@ -176,18 +192,15 @@ class GenericHeaderTest extends TestCase
         $this->assertSame('UTF-8', $header->getEncoding());
     }
 
-    public function testToStringThrowsWithoutFieldName(): void
+    public function testCannotInstantiateWithoutFieldName(): void
     {
-        $header = new GenericHeader();
-
-        $this->expectException(Exception\RuntimeException::class);
-        $this->expectExceptionMessage('Header name is not set, use setFieldName()');
-        $header->toString();
+        $this->expectException(InvalidArgumentException::class);
+        new GenericHeader();
     }
 
     public function testChangeEncodingToAsciiNotAllowedWhenHeaderValueContainsUtf8Characters(): void
     {
-        $subject = new GenericHeader();
+        $subject = new GenericHeader('Subject');
         $subject->setFieldValue('Accents òàùèéì');
 
         $this->assertSame('UTF-8', $subject->getEncoding());

--- a/test/Storage/ImapTest.php
+++ b/test/Storage/ImapTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Mail\Storage;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Mail\Protocol;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
@@ -87,7 +87,7 @@ class ImapTest extends TestCase
 
     public function testConnectConfig(): void
     {
-        new Storage\Imap(new Config\Config($this->params));
+        new Storage\Imap(new ArrayObject($this->params));
     }
 
     public function testConnectFailure(): void

--- a/test/Storage/MaildirFolderTest.php
+++ b/test/Storage/MaildirFolderTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Mail\Storage;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Mail\Storage\Exception;
 use Laminas\Mail\Storage\Folder;
 use PHPUnit\Framework\TestCase;
@@ -125,7 +125,7 @@ class MaildirFolderTest extends TestCase
 
     public function testLoadConfig(): void
     {
-        $mail = new Folder\Maildir(new Config\Config($this->params));
+        $mail = new Folder\Maildir(new ArrayObject($this->params));
         $this->assertSame(Folder\Maildir::class, \get_class($mail));
     }
 

--- a/test/Storage/MaildirFolderTest.php
+++ b/test/Storage/MaildirFolderTest.php
@@ -132,14 +132,14 @@ class MaildirFolderTest extends TestCase
     public function testNoParams(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('no valid dirname given in params');
+        $this->expectExceptionMessage('no dirname provided');
         new Folder\Maildir([]);
     }
 
     public function testLoadFailure(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('no valid dirname given in params');
+        $this->expectExceptionMessage('not a directory');
         new Folder\Maildir(['dirname' => 'This/Folder/Does/Not/Exist']);
     }
 

--- a/test/Storage/MaildirTest.php
+++ b/test/Storage/MaildirTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Mail\Storage;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
 use PHPUnit\Framework\TestCase;
@@ -113,7 +113,7 @@ class MaildirTest extends TestCase
 
     public function testLoadConfig(): void
     {
-        $mail = new Storage\Maildir(new Config\Config(['dirname' => $this->maildir]));
+        $mail = new Storage\Maildir(new ArrayObject(['dirname' => $this->maildir]));
         $this->assertSame(Storage\Maildir::class, \get_class($mail));
     }
 

--- a/test/Storage/MaildirTest.php
+++ b/test/Storage/MaildirTest.php
@@ -120,7 +120,7 @@ class MaildirTest extends TestCase
     public function testLoadFailure(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('no valid dirname given in params');
+        $this->expectExceptionMessage('not a directory');
         new Storage\Maildir(['dirname' => '/This/Dir/Does/Not/Exist']);
     }
 

--- a/test/Storage/MboxFolderTest.php
+++ b/test/Storage/MboxFolderTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Mail\Storage;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Mail\Storage\Exception;
 use Laminas\Mail\Storage\Folder;
 use PHPUnit\Framework\TestCase;
@@ -89,7 +89,7 @@ class MboxFolderTest extends TestCase
 
     public function testLoadConfig(): void
     {
-        new Folder\Mbox(new Config\Config($this->params));
+        new Folder\Mbox(new ArrayObject($this->params));
         $this->addToAssertionCount(1);
     }
 

--- a/test/Storage/MboxTest.php
+++ b/test/Storage/MboxTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Mail\Storage;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
 use PHPUnit\Framework\TestCase;
@@ -63,7 +63,7 @@ class MboxTest extends TestCase
 
     public function testLoadConfig(): void
     {
-        new Storage\Mbox(new Config\Config(['filename' => $this->mboxFile]));
+        new Storage\Mbox(new ArrayObject(['filename' => $this->mboxFile]));
         $this->addToAssertionCount(1);
     }
 

--- a/test/Storage/ParamsNormalizerTest.php
+++ b/test/Storage/ParamsNormalizerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace LaminasTest\Mail\Storage;
+
+use ArrayIterator;
+use InvalidArgumentException;
+use Laminas\Mail\Storage\ParamsNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class ParamsNormalizerTest extends TestCase
+{
+    /** @psalm-return iterable<string, array{0: mixed}> */
+    public function invalidParams(): iterable
+    {
+        yield 'null'         => [null];
+        yield 'bool'         => [true];
+        yield 'int'          => [1];
+        yield 'float'        => [1.1];
+        yield 'string'       => ['string'];
+        yield 'list'         => [[1, 2, 3]];
+    }
+
+    /**
+     * @dataProvider invalidParams
+     * @param mixed $params
+     */
+    public function testRaisesErrorOnInvalidParamsTypes($params): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ParamsNormalizer::normalizeParams($params);
+    }
+
+    public function testReturnsArrayMapVerbatim(): void
+    {
+        $params = [
+            'foo' => 'bar',
+            'baz' => [
+                'this' => 'that',
+            ],
+            'some' => 1,
+            'thing' => 1.1,
+            'else' => null,
+            'here' => (object) ['foo' => 'bar'],
+        ];
+
+        self::assertSame($params, ParamsNormalizer::normalizeParams($params));
+    }
+
+    public function testConvertsIterableMapToArrayMap(): void
+    {
+        $paramsArray = [
+            'foo' => 'bar',
+            'baz' => [
+                'this' => 'that',
+            ],
+            'some' => 1,
+            'thing' => 1.1,
+            'else' => null,
+            'here' => (object) ['foo' => 'bar'],
+        ];
+        $params = new ArrayIterator($paramsArray);
+
+        self::assertSame($paramsArray, ParamsNormalizer::normalizeParams($params));
+    }
+
+    public function testConvertsObjectToArrayMap(): void
+    {
+        $paramsArray = [
+            'foo' => 'bar',
+            'baz' => [
+                'this' => 'that',
+            ],
+            'some' => 1,
+            'thing' => 1.1,
+            'else' => null,
+            'here' => (object) ['foo' => 'bar'],
+        ];
+        $params = (object) $paramsArray;
+
+        self::assertSame($paramsArray, ParamsNormalizer::normalizeParams($params));
+    }
+}

--- a/test/Storage/Pop3Test.php
+++ b/test/Storage/Pop3Test.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Mail\Storage;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Mail\Protocol;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
@@ -92,7 +92,7 @@ class Pop3Test extends TestCase
 
     public function testConnectConfig(): void
     {
-        new Storage\Pop3(new Config\Config($this->params));
+        new Storage\Pop3(new ArrayObject($this->params));
     }
 
     public function testConnectFailure(): void


### PR DESCRIPTION
This patch provides PHP 8.1 support for laminas-mail via the following changes:

- Adds `~8.1.0` to the list of allowed PHP versions
- Bumps dependencies to versions known to work with 8.0/8.1 where possible
- Removes laminas-config as a dependency
  - It was a soft dependency previously; the source code did not directly reference it.
  - Refactoring of storage adapters was done to normalize options/params to associative arrays; this will also work on laminas-config instances, providing backwards compatibility.
- Changes how the package replaces zend-mail
  - Renames "replace" section to "conflict"
  - Changes "zend-mail" constraint in that section to "*"
  - Removes dependency on laminas-zendframework-bridge
- Adds `#[ReturnTypeWillChange]` attributes where needed
- When ext-intl is present, we now use `idn_to_ascii()` for punycode conversion, as the true/punycode package raises errors due to "implicit float to int conversion" under 8.1, leading to broken punycode conversion.
- `list() = explode()` raises a warning under 8.1 if an index is not created, vs a notice in previous versions; the patch ~~now detects this~~ refactors these to test for delimiters before attempting to explode a string.
