### PR TITLE
Fold a string with the correct length

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "~8.0.0 || ~8.1.0",
         "ext-iconv": "*",
         "laminas/laminas-loader": "^2.8.0",
-        "laminas/laminas-mime": "^2.9.1",
+        "laminas/laminas-mime": "^2.10.0",
         "laminas/laminas-stdlib": "^3.11.0",
         "laminas/laminas-validator": "^2.23.0",
         "symfony/polyfill-mbstring": "^1.16.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28854bcc582329d9db39a80e3684cb54",
+    "content-hash": "efe628d1dc2dfb55a59c5ecba304fe95",
     "packages": [
         {
             "name": "laminas/laminas-loader",

--- a/src/Header/HeaderWrap.php
+++ b/src/Header/HeaderWrap.php
@@ -12,9 +12,11 @@ use function iconv_mime_decode;
 use function iconv_mime_encode;
 use function implode;
 use function str_contains;
+use function str_pad;
 use function str_starts_with;
 use function strlen;
 use function strpos;
+use function substr;
 use function wordwrap;
 
 use const ICONV_MIME_DECODE_CONTINUE_ON_ERROR;
@@ -52,11 +54,23 @@ abstract class HeaderWrap
      */
     protected static function wrapUnstructuredHeader($value, HeaderInterface $header)
     {
-        $encoding = $header->getEncoding();
+        $headerNameColonSize = strlen($header->getFieldName() . ': ');
+        $encoding            = $header->getEncoding();
+
         if ($encoding == 'ASCII') {
-            return wordwrap($value, 78, Headers::FOLDING);
+            /*
+             * Before folding the header line, it is necessary to calculate the length of the
+             * entire header (including the name and colon). We need to put a stub at the
+             * beginning of the value so that the folding is performed correctly.
+             */
+            $headerLine       = str_pad('0', $headerNameColonSize, '0') . $value;
+            $foldedHeaderLine = wordwrap($headerLine, 78, Headers::FOLDING);
+
+            // Remove the stub and return the header folded value.
+            return substr($foldedHeaderLine, $headerNameColonSize);
         }
-        return static::mimeEncodeValue($value, $encoding, 78);
+
+        return static::mimeEncodeValue($value, $encoding, 78, $headerNameColonSize);
     }
 
     /**
@@ -88,14 +102,19 @@ abstract class HeaderWrap
      * Performs quoted-printable encoding on a value, setting maximum
      * line-length to 998.
      *
-     * @param  string $value
-     * @param  string $encoding
-     * @param  int    $lineLength maximum line-length, by default 998
+     * @param string $value
+     * @param string $encoding
+     * @param int    $lineLength       maximum line-length, by default 998
+     * @param int    $firstLineGapSize When folding a line, it is necessary to calculate
+     *                                 the length of the entire line (together with the header name).
+     *                                 Therefore, you can specify the header name and colon length
+     *                                 in this argument to fold the string properly.
+     *
      * @return string Returns the mime encode value without the last line ending
      */
-    public static function mimeEncodeValue($value, $encoding, $lineLength = 998)
+    public static function mimeEncodeValue($value, $encoding, $lineLength = 998, $firstLineGapSize = 0)
     {
-        return Mime::encodeQuotedPrintableHeader($value, $encoding, $lineLength, Headers::EOL);
+        return Mime::encodeQuotedPrintableHeader($value, $encoding, $lineLength, Headers::EOL, $firstLineGapSize);
     }
 
     /**

--- a/src/Header/HeaderWrap.php
+++ b/src/Header/HeaderWrap.php
@@ -102,14 +102,14 @@ abstract class HeaderWrap
      * Performs quoted-printable encoding on a value, setting maximum
      * line-length to 998.
      *
-     * @param string $value
-     * @param string $encoding
-     * @param int    $lineLength       maximum line-length, by default 998
-     * @param int    $firstLineGapSize When folding a line, it is necessary to calculate
-     *                                 the length of the entire line (together with the header name).
-     *                                 Therefore, you can specify the header name and colon length
-     *                                 in this argument to fold the string properly.
-     *
+     * @param string            $value
+     * @param string            $encoding
+     * @param int               $lineLength         Maximum line-length, by default 998
+     * @param positive-int|0    $firstLineGapSize   When folding a line, it is necessary to calculate
+     *                                              the length of the entire line (together with the
+     *                                              header name). Therefore, you can specify the header
+     *                                              name and colon length in this argument to fold the
+     *                                              string properly.
      * @return string Returns the mime encode value without the last line ending
      */
     public static function mimeEncodeValue($value, $encoding, $lineLength = 998, $firstLineGapSize = 0)

--- a/test/Header/SubjectTest.php
+++ b/test/Header/SubjectTest.php
@@ -7,7 +7,6 @@ use Laminas\Mail\Header\Exception;
 use PHPUnit\Framework\TestCase;
 
 use function str_repeat;
-use function wordwrap;
 
 /**
  * @group      Laminas_Mail
@@ -21,7 +20,10 @@ class SubjectTest extends TestCase
         $subject = new Header\Subject();
         $subject->setSubject($string);
 
-        $expected = wordwrap($string, 78, "\r\n ");
+        $expected = "foobarblahblahblah baz batfoobarblahblahblah baz\r\n "
+                    . "batfoobarblahblahblah baz batfoobarblahblahblah baz batfoobarblahblahblah baz\r\n "
+                    . "batfoobarblahblahblah baz batfoobarblahblahblah baz batfoobarblahblahblah baz\r\n "
+                    . "batfoobarblahblahblah baz batfoobarblahblahblah baz bat";
         $test     = $subject->getFieldValue(Header\HeaderInterface::FORMAT_ENCODED);
         $this->assertEquals($expected, $test);
     }

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -884,8 +884,8 @@ class MessageTest extends TestCase
         $mail       = Message::fromString($rawMessage);
 
         $this->assertStringContainsString(
-            'Subject: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
-            . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
+            'Subject: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20?=' . "\r\n"
+            . ' =?UTF-8?Q?accented=20vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
             $mail->toString()
         );
     }
@@ -896,8 +896,8 @@ class MessageTest extends TestCase
         $mail->setSubject('Non “ascii” characters like accented vowels òàùèéì');
 
         $this->assertStringContainsString(
-            'Subject: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
-            . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
+            'Subject: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20?=' . "\r\n"
+            . ' =?UTF-8?Q?accented=20vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
             $mail->toString()
         );
     }
@@ -909,8 +909,8 @@ class MessageTest extends TestCase
         $mail->getHeaders()->addHeader($header);
 
         $this->assertStringContainsString(
-            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
-            . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
+            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20?=' . "\r\n"
+            . ' =?UTF-8?Q?accented=20vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
             $mail->toString()
         );
     }
@@ -924,8 +924,8 @@ class MessageTest extends TestCase
         $mail->setHeaders($headers);
 
         $this->assertStringContainsString(
-            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
-            . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
+            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20?=' . "\r\n"
+            . ' =?UTF-8?Q?accented=20vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
             $mail->toString()
         );
     }
@@ -939,8 +939,8 @@ class MessageTest extends TestCase
         $mail->getHeaders()->addHeader($header);
 
         $this->assertStringContainsString(
-            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
-            . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
+            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20?=' . "\r\n"
+            . ' =?UTF-8?Q?accented=20vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=',
             $mail->toString()
         );
     }
@@ -957,8 +957,8 @@ class MessageTest extends TestCase
         $mail->setHeaders($headers);
 
         $this->assertStringContainsString(
-            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20accented=20?=' . "\r\n"
-            . ' =?UTF-8?Q?vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=' . "\r\n",
+            'X-Test: =?UTF-8?Q?Non=20=E2=80=9Cascii=E2=80=9D=20characters=20like=20?=' . "\r\n"
+            . ' =?UTF-8?Q?accented=20vowels=20=C3=B2=C3=A0=C3=B9=C3=A8=C3=A9=C3=AC?=',
             $mail->toString()
         );
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

According to the RFC 2822 specification (clause 2.1.1), the header length should be no more than 78 characters.

> Each line of characters MUST be no more than 998 characters, and SHOULD be no more than 78 characters, excluding the CRLF.

According to the specification, the length of the ENTIRE LINE should not exceed 78 characters. Currently, the `laminas-mail` library only counts the length of a **value** of the header. 

### Reproducing the problem
```
$message = new Message();
$message->addFrom('matthew@example.org', 'Matthew Somelli');
$message->addTo('foobar@example.com');
$message->setSubject('xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx');
$message->setBody('This is the message body.');

echo $message->toString();
```

This code will return the following result.

> Date: Thu, 21 Oct 2021 09:59:33 +0000
> From: Matthew Somelli <matthew@example.org>
> To: foobar@example.com
> Subject: xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx
> 
> This is the message body.

As you can see from the example, the header is longer than 78 characters.

### New code behavior

This commit has fixed this issue. In this pool request, the code above will return the following result.

> Date: Thu, 21 Oct 2021 10:04:43 +0000
> From: Matthew Somelli <matthew@example.org>
> To: foobar@example.com
> Subject: xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx xxxxx
>  xxxxx xxxxx
> 
> This is the message body.
> 

Now, the title does not exceed 78 characters.

### Note
Waiting for pooling request on [laminas-mime](https://github.com/laminas/laminas-mime/pull/25)