### PR TITLE
Drop `true/Punycode` in favor of `symfony/polyfill-intl-idn`

### DIFF
--- a/.laminas-ci/pre-run.sh
+++ b/.laminas-ci/pre-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+INTL_EXTENSION=$(php -r 'echo sprintf("php%s.%s-intl",PHP_MAJOR_VERSION,PHP_MINOR_VERSION);')
+
+echo -e "Removing $INTL_EXTENSION extension:\n"
+sudo apt remove "$INTL_EXTENSION" -y
+
+echo -e "Cleaning up:\n"
+sudo apt autoclean && sudo apt autoremove
+
+echo -e "Installed extensions:\n"
+/usr/local/bin/php-extensions-with-version.php

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "laminas/laminas-stdlib": "^3.6",
         "laminas/laminas-validator": "^2.15",
         "symfony/polyfill-mbstring": "^1.12.0",
-        "true/punycode": "^2.1",
         "webmozart/assert": "^1.10"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "laminas/laminas-stdlib": "^3.6",
         "laminas/laminas-validator": "^2.15",
         "symfony/polyfill-mbstring": "^1.12.0",
-        "webmozart/assert": "^1.10"
-        "symfony/polyfill-intl-idn": "^1.24.0",
+        "webmozart/assert": "^1.10",
+        "symfony/polyfill-intl-idn": "^1.24.0"
     },
     "conflict": {
         "zendframework/zend-mail": "*"
@@ -36,7 +36,10 @@
         "laminas/laminas-servicemanager": "^2.7.10 || ^3.3.1 when using SMTP to deliver messages"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     },
     "extra": {
         "laminas": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laminas/laminas-validator": "^2.15",
         "symfony/polyfill-mbstring": "^1.12.0",
         "webmozart/assert": "^1.10"
+        "symfony/polyfill-intl-idn": "^1.24.0",
     },
     "conflict": {
         "zendframework/zend-mail": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5831a1c6e28db10afe471ae508c67b81",
+    "content-hash": "7a9a1c865dc1954011cd112109c721f1",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -161,16 +161,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.6.0",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "c53d8537f108fac3fae652677a19735db730ba46"
+                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/c53d8537f108fac3fae652677a19735db730ba46",
-                "reference": "c53d8537f108fac3fae652677a19735db730ba46",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
+                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
                 "shasum": ""
             },
             "require": {
@@ -181,8 +181,8 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.3.0",
-                "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "~9.3.7",
+                "phpbench/phpbench": "^1.0",
+                "phpunit/phpunit": "^9.3.7",
                 "psalm/plugin-phpunit": "^0.16.0",
                 "vimeo/psalm": "^4.7"
             },
@@ -216,20 +216,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-02T16:11:32+00:00"
+            "time": "2022-01-10T11:18:55+00:00"
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.15.0",
+            "version": "2.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9"
+                "reference": "fbd87f30c0a27aaeeee8adb2f934c14fb6046c80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/270380e87904f5a1a1fba3059989d4ca157e16a9",
-                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/fbd87f30c0a27aaeeee8adb2f934c14fb6046c80",
+                "reference": "fbd87f30c0a27aaeeee8adb2f934c14fb6046c80",
                 "shasum": ""
             },
             "require": {
@@ -306,7 +306,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-08T23:16:56+00:00"
+            "time": "2021-12-02T14:23:06+00:00"
         },
         {
             "name": "psr/container",
@@ -358,20 +358,23 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -417,7 +420,178 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-20T20:35:02+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "749045c69efb97c70d25d7463abba812e91f3a44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/749045c69efb97c70d25d7463abba812e91f3a44",
+                "reference": "749045c69efb97c70d25d7463abba812e91f3a44",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-14T14:02:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -437,20 +611,23 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -497,7 +674,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -513,35 +690,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2021-11-30T18:21:41+00:00"
         },
         {
-            "name": "true/punycode",
-            "version": "v2.1.1",
+            "name": "symfony/polyfill-php72",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/true/php-punycode.git",
-                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e"
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/true/php-punycode/zipball/a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
-                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "symfony/polyfill-mbstring": "^1.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.7",
-                "squizlabs/php_codesniffer": "~2.0"
+                "php": ">=7.1"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "TrueBV\\": "src/"
-                }
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -549,21 +733,40 @@
             ],
             "authors": [
                 {
-                    "name": "Renan Gonçalves",
-                    "email": "renan.saddam@gmail.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
-            "homepage": "https://github.com/true/php-punycode",
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
             "keywords": [
-                "idna",
-                "punycode"
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
             ],
             "support": {
-                "issues": "https://github.com/true/php-punycode/issues",
-                "source": "https://github.com/true/php-punycode/tree/master"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.24.0"
             },
-            "time": "2016-11-16T10:37:54+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -627,16 +830,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.0",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc"
+                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
-                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
+                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
                 "shasum": ""
             },
             "require": {
@@ -704,7 +907,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.0"
+                "source": "https://github.com/amphp/amp/tree/v2.6.1"
             },
             "funding": [
                 {
@@ -712,7 +915,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-16T20:06:06+00:00"
+            "time": "2021-09-23T18:43:08+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -865,17 +1068,88 @@
             "time": "2021-09-13T08:41:34+00:00"
         },
         {
-            "name": "composer/semver",
-            "version": "3.2.5",
+            "name": "composer/pcre",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
-                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/3d322d715c43a1ac36c7fe215fa59336265500f2",
+                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-12-06T15:17:27+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "deac27056b57e46faf136fae7b449eeaa71661ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/deac27056b57e46faf136fae7b449eeaa71661ee",
+                "reference": "deac27056b57e46faf136fae7b449eeaa71661ee",
                 "shasum": ""
             },
             "require": {
@@ -927,7 +1201,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.5"
+                "source": "https://github.com/composer/semver/tree/3.2.7"
             },
             "funding": [
                 {
@@ -943,29 +1217,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-24T12:41:47+00:00"
+            "time": "2022-01-04T09:57:54+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
+                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
-                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/12f1b79476638a5615ed00ea6adbb269cec96fd8",
+                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "composer/pcre": "^1",
+                "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -991,7 +1267,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1007,7 +1283,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-31T17:03:58+00:00"
+            "time": "2022-01-04T18:29:42+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1260,28 +1536,27 @@
         },
         {
             "name": "laminas/laminas-crypt",
-            "version": "3.4.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-crypt.git",
-                "reference": "a058eeb2fe57824b958ac56753faff790a649e18"
+                "reference": "ad2c29c289a4bc837b37a7650f5178edda0fc548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-crypt/zipball/a058eeb2fe57824b958ac56753faff790a649e18",
-                "reference": "a058eeb2fe57824b958ac56753faff790a649e18",
+                "url": "https://api.github.com/repos/laminas/laminas-crypt/zipball/ad2c29c289a4bc837b37a7650f5178edda0fc548",
+                "reference": "ad2c29c289a4bc837b37a7650f5178edda0fc548",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
                 "ext-mbstring": "*",
-                "laminas/laminas-math": "^3.0",
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-math": "^3.4",
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-crypt": "^3.3.1"
+            "conflict": {
+                "zendframework/zend-crypt": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~1.0.0",
@@ -1320,7 +1595,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-11T19:40:03+00:00"
+            "time": "2021-12-06T01:25:27+00:00"
         },
         {
             "name": "laminas/laminas-db",
@@ -1395,29 +1670,28 @@
         },
         {
             "name": "laminas/laminas-math",
-            "version": "3.3.2",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-math.git",
-                "reference": "188456530923a449470963837c25560f1fdd8a60"
+                "reference": "146d8187ab247ae152e811a6704a953d43537381"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/188456530923a449470963837c25560f1fdd8a60",
-                "reference": "188456530923a449470963837c25560f1fdd8a60",
+                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/146d8187ab247ae152e811a6704a953d43537381",
+                "reference": "146d8187ab247ae152e811a6704a953d43537381",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-math": "^3.2.0"
+            "conflict": {
+                "zendframework/zend-math": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "ext-bcmath": "If using the bcmath functionality",
@@ -1459,7 +1733,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-16T15:46:01+00:00"
+            "time": "2021-12-06T02:02:07+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -1552,16 +1826,16 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
+                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
+                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
                 "shasum": ""
             },
             "require": {
@@ -1610,7 +1884,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-03T17:53:30+00:00"
+            "time": "2021-12-21T14:34:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1628,9 +1902,6 @@
             },
             "require": {
                 "php": "^7.1 || ^8.0"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
@@ -1723,16 +1994,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.0",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50953a2691a922aa1769461637869a0a2faa3f53",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -1773,9 +2044,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2021-09-20T12:20:58+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -1996,16 +2267,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -2016,7 +2287,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -2046,22 +2318,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f"
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30f38bffc6f24293dadd1823936372dfa9e86e2f",
-                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
                 "shasum": ""
             },
             "require": {
@@ -2096,22 +2368,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
             },
-            "time": "2021-09-17T15:28:14+00:00"
+            "time": "2022-01-04T19:58:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
@@ -2163,29 +2435,29 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2021-09-10T09:02:12+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.7",
+            "version": "9.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d4c798ed8d51506800b441f7a13ecb0f76f12218"
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d4c798ed8d51506800b441f7a13ecb0f76f12218",
-                "reference": "d4c798ed8d51506800b441f7a13ecb0f76f12218",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.12.0",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2234,7 +2506,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
             },
             "funding": [
                 {
@@ -2242,20 +2514,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-17T05:39:03+00:00"
+            "time": "2021-12-05T09:12:13+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -2294,7 +2566,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -2302,7 +2574,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2487,16 +2759,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.9",
+            "version": "9.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
+                "reference": "2406855036db1102126125537adb1406f7242fdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
-                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2406855036db1102126125537adb1406f7242fdd",
+                "reference": "2406855036db1102126125537adb1406f7242fdd",
                 "shasum": ""
             },
             "require": {
@@ -2512,7 +2784,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -2574,11 +2846,11 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.11"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -2586,7 +2858,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-08-31T06:47:40+00:00"
+            "time": "2021-12-25T07:07:57+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3127,16 +3399,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -3185,14 +3457,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -3200,7 +3472,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3747,26 +4019,26 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.7",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a"
+                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8b1008344647462ae6ec57559da166c2bfa5e16a",
-                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a2c6b7ced2eb7799a35375fb9022519282b5405e",
+                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php73": "^1.9",
                 "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
                 "psr/log": ">=3",
@@ -3781,12 +4053,12 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -3826,7 +4098,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.7"
+                "source": "https://github.com/symfony/console/tree/v5.4.2"
             },
             "funding": [
                 {
@@ -3842,20 +4114,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-25T20:02:16+00:00"
+            "time": "2021-12-20T16:11:12+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
                 "shasum": ""
             },
             "require": {
@@ -3864,7 +4136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3893,7 +4165,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -3909,20 +4181,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "time": "2021-07-12T14:48:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
-                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
                 "shasum": ""
             },
             "require": {
@@ -3974,7 +4246,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -3990,104 +4262,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-11-23T21:10:46+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.23.0",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/cc5db0e22b3cb4111010e48785a97f670b350ca5",
+                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5",
                 "shasum": ""
             },
             "require": {
@@ -4137,7 +4325,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -4153,20 +4341,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-06-05T21:20:04+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
                 "shasum": ""
             },
             "require": {
@@ -4220,7 +4408,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -4236,20 +4424,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-28T13:41:28+00:00"
+            "time": "2021-09-13T13:58:33+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.3.7",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "38f26c7d6ed535217ea393e05634cb0b244a1967"
+                "reference": "2b3ba8722c4aaf3e88011be5e7f48710088fb5e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/38f26c7d6ed535217ea393e05634cb0b244a1967",
-                "reference": "38f26c7d6ed535217ea393e05634cb0b244a1967",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2b3ba8722c4aaf3e88011be5e7f48710088fb5e4",
+                "reference": "2b3ba8722c4aaf3e88011be5e7f48710088fb5e4",
                 "shasum": ""
             },
             "require": {
@@ -4282,7 +4470,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.3.7"
+                "source": "https://github.com/symfony/process/tree/v5.4.2"
             },
             "funding": [
                 {
@@ -4298,25 +4486,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-04T21:20:46+00:00"
+            "time": "2021-12-27T21:01:00+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.1"
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -4324,7 +4516,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4361,7 +4553,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -4377,20 +4569,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T10:43:52+00:00"
+            "time": "2021-11-04T16:48:04+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.3.7",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5"
+                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8d224396e28d30f81969f083a58763b8b9ceb0a5",
-                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
+                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
                 "shasum": ""
             },
             "require": {
@@ -4401,11 +4593,14 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "~1.15"
             },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4444,7 +4639,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.7"
+                "source": "https://github.com/symfony/string/tree/v5.4.2"
             },
             "funding": [
                 {
@@ -4460,7 +4655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-26T08:00:08+00:00"
+            "time": "2021-12-16T21:52:00+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4514,16 +4709,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.10.0",
+            "version": "4.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa"
+                "reference": "dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/916b098b008f6de4543892b1e0651c1c3b92cbfa",
-                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb",
+                "reference": "dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb",
                 "shasum": ""
             },
             "require": {
@@ -4531,7 +4726,7 @@
                 "amphp/byte-stream": "^1.5",
                 "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-ctype": "*",
                 "ext-dom": "*",
@@ -4543,11 +4738,11 @@
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.12",
+                "nikic/php-parser": "^4.13",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
-                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -4565,11 +4760,12 @@
                 "psalm/plugin-phpunit": "^0.16",
                 "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/process": "^4.3 || ^5.0",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
-                "ext-igbinary": "^2.0.5"
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
             },
             "bin": [
                 "psalm",
@@ -4613,9 +4809,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.10.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.18.1"
             },
-            "time": "2021-09-04T21:00:09+00:00"
+            "time": "2022-01-08T21:21:26+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -4665,6 +4861,7 @@
                 "issues": "https://github.com/webmozart/path-util/issues",
                 "source": "https://github.com/webmozart/path-util/tree/2.3.0"
             },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
@@ -4678,5 +4875,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
+<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
   <file src="src/Address.php">
     <DocblockTypeContradiction occurrences="2">
       <code>! is_string($email)</code>
@@ -39,7 +39,7 @@
   </file>
   <file src="src/AddressList.php">
     <DocblockTypeContradiction occurrences="2">
-      <code>$emailOrAddress instanceof Address\AddressInterface</code>
+      <code>gettype($emailOrAddress)</code>
       <code>is_string($key)</code>
     </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="1">
@@ -71,8 +71,9 @@
     <PossiblyNullArgument occurrences="1">
       <code>is_object($key) ? get_class($key) : var_export($key, 1)</code>
     </PossiblyNullArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType occurrences="2">
       <code>$key !== false</code>
+      <code>is_object($emailOrAddress)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Header/AbstractAddressList.php">
@@ -199,10 +200,6 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>GenericHeader</code>
     </LessSpecificImplementedReturnType>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $fieldValue</code>
     </RedundantCastGivenDocblockType>
@@ -245,10 +242,6 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Header/HeaderWrap.php">
-    <MissingClosureParamType occurrences="2">
-      <code>$accumulator</code>
-      <code>$headerPart</code>
-    </MissingClosureParamType>
     <MissingParamType occurrences="2">
       <code>$originalValue</code>
       <code>$value</code>
@@ -319,13 +312,15 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Header/Sender.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>$emailOrAddress instanceof Mail\Address\AddressInterface</code>
-      <code>$this-&gt;address instanceof Mail\Address\AddressInterface</code>
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($emailOrAddress)</code>
     </DocblockTypeContradiction>
     <MissingConstructor occurrences="1">
       <code>$address</code>
     </MissingConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($emailOrAddress)</code>
+    </RedundantConditionGivenDocblockType>
     <UnsafeInstantiation occurrences="1">
       <code>new static()</code>
     </UnsafeInstantiation>
@@ -346,7 +341,7 @@
   </file>
   <file src="src/Headers.php">
     <DocblockTypeContradiction occurrences="4">
-      <code>! is_array($headers) &amp;&amp; ! $headers instanceof Traversable</code>
+      <code>gettype($headers)</code>
       <code>is_array($fieldValue)</code>
       <code>is_array($headers)</code>
       <code>is_string($headerFieldNameOrLine)</code>
@@ -412,6 +407,9 @@
       <code>$this-&gt;getHeaderLocator()-&gt;get($key, Header\GenericHeader::class)</code>
       <code>$this-&gt;headerLocator</code>
     </NullableReturnStatement>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($headers)</code>
+    </RedundantConditionGivenDocblockType>
     <UnsafeInstantiation occurrences="1">
       <code>new static()</code>
     </UnsafeInstantiation>
@@ -426,8 +424,7 @@
       <code>$emailOrAddressList</code>
       <code>$header</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="4">
-      <code>$from instanceof AddressList</code>
+    <DocblockTypeContradiction occurrences="3">
       <code>gettype($emailOrAddressOrList)</code>
       <code>is_object($body)</code>
       <code>null === $this-&gt;headers</code>
@@ -493,7 +490,7 @@
   </file>
   <file src="src/MessageFactory.php">
     <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($options) &amp;&amp; ! $options instanceof Traversable</code>
+      <code>gettype($options)</code>
     </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$key</code>
@@ -502,21 +499,20 @@
       <code>$key</code>
       <code>$value</code>
     </MixedAssignment>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($options)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Protocol/AbstractProtocol.php">
     <DocblockTypeContradiction occurrences="1">
       <code>$cmd === null</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument occurrences="1">
       <code>Validator\Hostname::ALLOW_ALL</code>
     </InvalidArgument>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;socket</code>
     </InvalidPropertyAssignmentValue>
-    <MissingClosureParamType occurrences="2">
-      <code>$error</code>
-      <code>$message</code>
-    </MissingClosureParamType>
     <MissingReturnType occurrences="5">
       <code>_addLog</code>
       <code>_disconnect</code>
@@ -524,10 +520,6 @@
       <code>resetLog</code>
       <code>setMaximumLog</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$error</code>
-      <code>$message</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$this-&gt;log</code>
       <code>$this-&gt;validHost-&gt;getMessages()</code>
@@ -992,6 +984,9 @@
     <NullableReturnStatement occurrences="1">
       <code>isset($this-&gt;has[$var]) ? $this-&gt;has[$var] : null</code>
     </NullableReturnStatement>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;getMessage($id)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Storage/Folder.php">
     <ImplementedReturnTypeMismatch occurrences="2">
@@ -1013,7 +1008,8 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $this-&gt;getGlobalName()</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$current</code>
       <code>$current</code>
       <code>$current &amp;&amp; $current instanceof self</code>
     </RedundantConditionGivenDocblockType>
@@ -1069,10 +1065,12 @@
     <PossiblyNullArgument occurrences="1">
       <code>$parent</code>
     </PossiblyNullArgument>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition occurrences="2">
+      <code>$stack</code>
       <code>$stack</code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType occurrences="2">
+      <code>! $stack</code>
       <code>$stack</code>
     </TypeDoesNotContainType>
   </file>
@@ -1253,13 +1251,15 @@
       <code>store</code>
       <code>store</code>
     </PossiblyNullReference>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition occurrences="2">
+      <code>$stack</code>
       <code>$stack</code>
     </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$flags === null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType occurrences="2">
+      <code>! $stack</code>
       <code>$stack</code>
     </TypeDoesNotContainType>
   </file>
@@ -1286,10 +1286,6 @@
       <code>\Laminas\Mail\Storage\Exception\ExceptionInterface</code>
     </InvalidThrow>
     <LessSpecificReturnStatement occurrences="2"/>
-    <MissingClosureParamType occurrences="2">
-      <code>$a</code>
-      <code>$b</code>
-    </MissingClosureParamType>
     <MissingParamType occurrences="2">
       <code>$id</code>
       <code>$params</code>
@@ -1472,9 +1468,6 @@
     </MixedArrayOffset>
   </file>
   <file src="src/Storage/Part.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$this-&gt;headers instanceof Headers</code>
-    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="2">
       <code>Part</code>
       <code>string</code>
@@ -1512,8 +1505,7 @@
       <code>$part['body']</code>
       <code>$part['header']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
-      <code>$h</code>
+    <MixedAssignment occurrences="6">
       <code>$h</code>
       <code>$params['strict']</code>
       <code>$part</code>
@@ -1521,29 +1513,28 @@
       <code>$this-&gt;content</code>
       <code>$this-&gt;messageNum</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType occurrences="2">
       <code>Part</code>
+      <code>string</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="2">
       <code>getFieldValue</code>
       <code>getFieldValue</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$h-&gt;getFieldValue(HeaderInterface::FORMAT_RAW)</code>
-    </MixedOperand>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="3">
+      <code>$header-&gt;getFieldValue(HeaderInterface::FORMAT_RAW)</code>
       <code>$this-&gt;parts[$num]</code>
       <code>$this-&gt;parts[$num]</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument occurrences="3">
       <code>$boundary</code>
+      <code>$header</code>
       <code>$this-&gt;getHeader($name, 'array')</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast occurrences="1">
       <code>$boundary</code>
     </PossiblyInvalidCast>
-    <PossiblyInvalidIterator occurrences="2">
-      <code>$header</code>
+    <PossiblyInvalidIterator occurrences="1">
       <code>$header</code>
     </PossiblyInvalidIterator>
     <PossiblyNullArgument occurrences="4">
@@ -1552,7 +1543,8 @@
       <code>$this-&gt;headers</code>
       <code>$this-&gt;headers</code>
     </PossiblyNullArgument>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$current</code>
       <code>$current</code>
       <code>$current &amp;&amp; $current instanceof self</code>
     </RedundantConditionGivenDocblockType>
@@ -2033,16 +2025,16 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $this-&gt;parameters</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$from</code>
       <code>$from</code>
       <code>$this-&gt;errstr !== null</code>
       <code>gettype($callable)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Transport/Smtp.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction occurrences="2">
       <code>! ($connection instanceof Protocol\Smtp)</code>
-      <code>$this-&gt;connection instanceof Protocol\Smtp</code>
       <code>null === $this-&gt;plugins</code>
     </DocblockTypeContradiction>
     <InvalidCatch occurrences="1"/>
@@ -2384,13 +2376,11 @@
     <InvalidScalarArgument occurrences="1">
       <code>0</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="3">
-      <code>$fieldName</code>
+    <MissingParamType occurrences="2">
       <code>$line</code>
       <code>$message</code>
     </MissingParamType>
-    <MixedArgument occurrences="3">
-      <code>$fieldName</code>
+    <MixedArgument occurrences="2">
       <code>$line</code>
       <code>$message</code>
     </MixedArgument>
@@ -2547,6 +2537,12 @@
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
+    <UnevaluatedCode occurrences="4">
+      <code>$receivedHeader = new Header\Received();</code>
+      <code>$receivedHeader = new Header\Received();</code>
+      <code>$this-&gt;assertEmpty('Received: xxx', $receivedHeader-&gt;toString());</code>
+      <code>$this-&gt;assertEquals('xxx', $receivedHeader-&gt;getFieldValue());</code>
+    </UnevaluatedCode>
     <UnusedVariable occurrences="1">
       <code>$received</code>
     </UnusedVariable>
@@ -2606,7 +2602,7 @@
     <InternalClass occurrences="1">
       <code>new Deprecated($errstr, $errno, $errfile, $errline)</code>
     </InternalClass>
-    <InvalidArgument occurrences="4">
+    <InvalidArgument occurrences="3">
       <code>$object</code>
       <code>'foo'</code>
       <code>["foo-bar\r\n\r\nevilContent"]</code>
@@ -2664,9 +2660,6 @@
     <MixedArgument occurrences="1">
       <code>$options</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$value</code>
-    </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
@@ -2756,6 +2749,11 @@
     <UnusedClosureParam occurrences="1">
       <code>$type</code>
     </UnusedClosureParam>
+  </file>
+  <file src="test/Protocol/HttpStatusService/index.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>(int) $_GET['sleep']</code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="test/Protocol/ProtocolTraitTest.php">
     <InvalidScalarArgument occurrences="1">
@@ -3021,20 +3019,13 @@
       <code>$subdirs</code>
       <code>$tmpdir</code>
     </MissingPropertyType>
-    <MixedArgument occurrences="6">
-      <code>$stat['mode']</code>
-      <code>$stat['mode']</code>
+    <MixedArgument occurrences="4">
       <code>$this-&gt;params</code>
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;subdirs</code>
       <code>$this-&gt;tmpdir</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="12">
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
+    <MixedArrayAccess occurrences="7">
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
@@ -3046,48 +3037,19 @@
     <MixedArrayAssignment occurrences="1">
       <code>$this-&gt;params['folder']</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="6">
-      <code>$found_folders[$folder-&gt;__toString()]</code>
-      <code>$found_folders[$folder-&gt;__toString()]</code>
-      <code>$found_folders[$folder-&gt;__toString()]</code>
-      <code>$search_folders[$folder-&gt;getGlobalName()]</code>
-      <code>$search_folders[$folder-&gt;getGlobalName()]</code>
-      <code>$search_folders[$folder-&gt;getGlobalName()]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="4">
       <code>$dir</code>
       <code>$dir</code>
       <code>$folder</code>
-      <code>$folder</code>
-      <code>$folder</code>
-      <code>$folder</code>
-      <code>$found_folders[$folder-&gt;__toString()]</code>
-      <code>$found_folders[$folder-&gt;__toString()]</code>
-      <code>$found_folders[$folder-&gt;__toString()]</code>
-      <code>$localName</code>
-      <code>$localName</code>
-      <code>$localName</code>
       <code>$localName</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="7">
-      <code>__toString</code>
-      <code>__toString</code>
-      <code>__toString</code>
-      <code>getGlobalName</code>
-      <code>getGlobalName</code>
-      <code>getGlobalName</code>
+    <MixedMethodCall occurrences="1">
       <code>getLocalName</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="25">
+    <MixedOperand occurrences="19">
       <code>$dir</code>
       <code>$dir</code>
       <code>$dir</code>
-      <code>$statcheck['mode']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
@@ -3110,9 +3072,55 @@
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
     </PossiblyFalseArgument>
-    <UnusedVariable occurrences="1">
-      <code>$mail</code>
-    </UnusedVariable>
+    <UnevaluatedCode occurrences="56">
+      <code>$check = false;</code>
+      <code>$count = $mail-&gt;countMessages();</code>
+      <code>$count = $mail-&gt;countMessages();</code>
+      <code>$found_folders = [];</code>
+      <code>$found_folders = [];</code>
+      <code>$found_folders = [];</code>
+      <code>$iterator = new RecursiveIteratorIterator($mail-&gt;getFolders(), RecursiveIteratorIterator::SELF_FIRST);</code>
+      <code>$iterator = new RecursiveIteratorIterator($mail-&gt;getFolders(), RecursiveIteratorIterator::SELF_FIRST);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail = new Folder\Maildir($this-&gt;params);</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$search_folders = ['subfolder.test' =&gt; 'test'];</code>
+      <code>$shouldSizes = [1 =&gt; 397, 89, 694, 452, 497];</code>
+      <code>$sizes = $mail-&gt;getSize();</code>
+      <code>$sizes = $mail-&gt;getSize();</code>
+      <code>$stat = stat($this-&gt;params['dirname'] . '.subfolder');</code>
+      <code>$statcheck = stat($this-&gt;params['dirname'] . '.subfolder');</code>
+      <code>$subject = $mail-&gt;getMessage(1)-&gt;subject;</code>
+      <code>$subject = $mail-&gt;getMessage(1)-&gt;subject;</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getCurrentFolder(), 'subfolder.test');</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getFolders()-&gt;subfolder-&gt;__toString(), 'subfolder');</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getFolders()-&gt;subfolder-&gt;key(), 'test');</code>
+      <code>$this-&gt;assertEquals($search_folders, $found_folders);</code>
+      <code>$this-&gt;assertEquals($search_folders, $found_folders);</code>
+      <code>$this-&gt;assertEquals($search_folders, $found_folders);</code>
+      <code>$this-&gt;assertEquals($shouldSizes, $sizes);</code>
+      <code>$this-&gt;assertEquals('Message in subfolder', $subject);</code>
+      <code>$this-&gt;assertEquals('Simple Message', $subject);</code>
+      <code>$this-&gt;assertEquals(1, $count);</code>
+      <code>$this-&gt;assertEquals(5, $count);</code>
+      <code>$this-&gt;assertEquals([1 =&gt; 467], $sizes);</code>
+      <code>chmod($this-&gt;params['dirname'] . '.subfolder', $stat['mode']);</code>
+      <code>chmod($this-&gt;params['dirname'] . '.subfolder', 0);</code>
+      <code>clearstatcache();</code>
+      <code>return;</code>
+      <code>return;</code>
+      <code>return;</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Storage/MaildirMessageOldTest.php">
     <MissingPropertyType occurrences="2">
@@ -3132,6 +3140,11 @@
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
     </PossiblyFalseArgument>
+    <UnevaluatedCode occurrences="3">
+      <code>return;</code>
+      <code>return;</code>
+      <code>return;</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Storage/MaildirTest.php">
     <MissingPropertyType occurrences="2">
@@ -3188,6 +3201,11 @@
     <PossiblyInvalidIterator occurrences="1">
       <code>$ids</code>
     </PossiblyInvalidIterator>
+    <UnevaluatedCode occurrences="3">
+      <code>return;</code>
+      <code>return;</code>
+      <code>return;</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Storage/MaildirWritableTest.php">
     <MissingPropertyType occurrences="3">
@@ -3200,31 +3218,23 @@
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;subdirs</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>$this-&gt;params['dirname']</code>
+    <MixedArrayAccess occurrences="3">
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
       <code>$this-&gt;params['dirname']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="6">
+    <MixedArrayAssignment occurrences="1">
       <code>$this-&gt;params['create']</code>
-      <code>$this-&gt;subdirs[]</code>
-      <code>$this-&gt;subdirs[]</code>
-      <code>$this-&gt;subdirs[]</code>
-      <code>$this-&gt;subdirs[]</code>
-      <code>$this-&gt;subdirs[]</code>
     </MixedArrayAssignment>
     <MixedAssignment occurrences="2">
       <code>$dir</code>
       <code>$dir</code>
     </MixedAssignment>
-    <MixedOperand occurrences="18">
+    <MixedOperand occurrences="16">
       <code>$dir</code>
       <code>$dir</code>
       <code>$dir</code>
       <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;params['dirname']</code>
-      <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
@@ -3243,11 +3253,103 @@
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
     </PossiblyFalseArgument>
-    <UnusedVariable occurrences="6">
+    <UnevaluatedCode occurrences="96">
+      <code>$count = $mail-&gt;countMessages();</code>
+      <code>$fromCount = $mail-&gt;countMessages();</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail = new Writable\Maildir($this-&gt;params);</code>
+      <code>$mail-&gt;appendMessage("Subject: test\r\n\r\n");</code>
+      <code>$mail-&gt;appendMessage("Subject: test\r\n\r\n");</code>
+      <code>$mail-&gt;appendMessage("Subject: test\r\n\r\n");</code>
+      <code>$mail-&gt;copyMessage(1, 'justARandomFolder');</code>
+      <code>$mail-&gt;copyMessage(1, 'subfolder');</code>
+      <code>$mail-&gt;copyMessage(1, 'subfolder.test');</code>
+      <code>$mail-&gt;createFolder('foo.bar');</code>
+      <code>$mail-&gt;createFolder('subfolder.test1');</code>
+      <code>$mail-&gt;createFolder('test2', 'INBOX.subfolder');</code>
+      <code>$mail-&gt;createFolder('test3', $mail-&gt;getFolders()-&gt;subfolder);</code>
+      <code>$mail-&gt;moveMessage(1, $target);</code>
+      <code>$mail-&gt;removeFolder('subfolder.test');</code>
+      <code>$mail-&gt;removeMessage(1);</code>
+      <code>$mail-&gt;renameFolder('subfolder.test', 'foo');</code>
+      <code>$mail-&gt;selectFolder($mail-&gt;getFolders()-&gt;foo-&gt;bar);</code>
+      <code>$mail-&gt;selectFolder($mail-&gt;getFolders()-&gt;subfolder-&gt;test1);</code>
+      <code>$mail-&gt;selectFolder($mail-&gt;getFolders()-&gt;subfolder-&gt;test2);</code>
+      <code>$mail-&gt;selectFolder($mail-&gt;getFolders()-&gt;subfolder-&gt;test3);</code>
+      <code>$mail-&gt;selectFolder($target);</code>
+      <code>$mail-&gt;selectFolder($target);</code>
+      <code>$mail-&gt;selectFolder('INBOX');</code>
+      <code>$mail-&gt;selectFolder('INBOX');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;selectFolder('subfolder.test');</code>
+      <code>$mail-&gt;setQuota(['size' =&gt; 100, 'count' =&gt; 2, 'X' =&gt; 0]);</code>
+      <code>$mail-&gt;setQuota(['size' =&gt; 100, 'count' =&gt; 2, 'X' =&gt; 0]);</code>
+      <code>$mail-&gt;setQuota(['size' =&gt; 3000, 'count' =&gt; 5, 'X' =&gt; 0]);</code>
+      <code>$mail-&gt;setQuota(['size' =&gt; 3000, 'count' =&gt; 6, 'X' =&gt; 0]);</code>
+      <code>$mail-&gt;setQuota(['size' =&gt; 3000, 'count' =&gt; 6, 'X' =&gt; 0]);</code>
+      <code>$mail-&gt;setQuota(false);</code>
+      <code>$mail-&gt;setQuota(false);</code>
+      <code>$mail-&gt;setQuota(true);</code>
+      <code>$mail-&gt;setQuota(true);</code>
+      <code>$message = $mail-&gt;getMessage(1);</code>
+      <code>$target = $mail-&gt;getFolders()-&gt;subfolder-&gt;test;</code>
+      <code>$this-&gt;assertEquals($count + 1, $mail-&gt;countMessages());</code>
+      <code>$this-&gt;assertEquals($fromCount - 1, $mail-&gt;countMessages());</code>
+      <code>$this-&gt;assertEquals($mail-&gt;checkQuota(true), $quotaResult);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;checkQuota(true), $quotaResult);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;checkQuota(true), $quotaResult);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getMessage($count + 1)-&gt;from, $message-&gt;from);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getMessage($count + 1)-&gt;subject, $message-&gt;subject);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getMessage($count + 1)-&gt;to, $message-&gt;to);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getQuota(), ['size' =&gt; 100, 'count' =&gt; 2, 'X' =&gt; 0]);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getQuota(true), $quotaResult['quota']);</code>
+      <code>$this-&gt;assertEquals($mail-&gt;getQuota(true), ['size' =&gt; 3000, 'L' =&gt; 1, 'count' =&gt; 10]);</code>
+      <code>$this-&gt;assertEquals($quotaResult, $mail-&gt;checkQuota(true));</code>
+      <code>$this-&gt;assertEquals($quotaResult, $mail-&gt;checkQuota(true, true));</code>
+      <code>$this-&gt;assertEquals($toCount + 1, $mail-&gt;countMessages());</code>
+      <code>$this-&gt;assertEquals(['size' =&gt; 100, 'count' =&gt; 2, 'X' =&gt; 0], $mail-&gt;getQuota(true));</code>
+      <code>$this-&gt;assertFalse($mail-&gt;checkQuota());</code>
+      <code>$this-&gt;assertFalse($mail-&gt;checkQuota(false, true));</code>
+      <code>$this-&gt;assertFalse($mail-&gt;checkQuota(false, true));</code>
+      <code>$this-&gt;assertFalse($mail-&gt;getQuota());</code>
+      <code>$this-&gt;assertNull($mail-&gt;getQuota());</code>
+      <code>$this-&gt;assertTrue($mail-&gt;checkQuota());</code>
+      <code>$this-&gt;assertTrue($mail-&gt;checkQuota());</code>
+      <code>$this-&gt;assertTrue($mail-&gt;checkQuota(false, true));</code>
+      <code>$this-&gt;assertTrue($mail-&gt;getQuota());</code>
+      <code>$this-&gt;expectException(Exception\InvalidArgumentException::class);</code>
+      <code>$this-&gt;expectException(Exception\InvalidArgumentException::class);</code>
+      <code>$this-&gt;expectException(Exception\InvalidArgumentException::class);</code>
+      <code>$this-&gt;expectException(Exception\InvalidArgumentException::class);</code>
+      <code>$this-&gt;expectException(Exception\InvalidArgumentException::class);</code>
+      <code>$this-&gt;subdirs[] = '.foo';</code>
+      <code>$this-&gt;subdirs[] = '.foo.bar';</code>
+      <code>$this-&gt;subdirs[] = '.subfolder.test1';</code>
+      <code>$this-&gt;subdirs[] = '.subfolder.test2';</code>
+      <code>$this-&gt;subdirs[] = '.subfolder.test3';</code>
+      <code>$toCount = $mail-&gt;countMessages();</code>
+      <code>return;</code>
+      <code>return;</code>
+      <code>return;</code>
+      <code>unlink($this-&gt;params['dirname'] . 'cur/1000000000.P1.example.org:2,S');</code>
+      <code>unlink($this-&gt;tmpdir . 'maildirsize');</code>
+    </UnevaluatedCode>
+    <UnusedVariable occurrences="5">
       <code>$count</code>
       <code>$e</code>
       <code>$e</code>
-      <code>$mail</code>
       <code>$mail</code>
       <code>$mail</code>
     </UnusedVariable>
@@ -3334,6 +3436,10 @@
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
     </PossiblyFalseArgument>
+    <UnevaluatedCode occurrences="2">
+      <code>return;</code>
+      <code>return;</code>
+    </UnevaluatedCode>
     <UnusedVariable occurrences="1">
       <code>$mail</code>
     </UnusedVariable>
@@ -3371,6 +3477,9 @@
       <code>$this-&gt;tmpdir</code>
       <code>$this-&gt;tmpdir</code>
     </PossiblyFalseArgument>
+    <UnevaluatedCode occurrences="1">
+      <code>return;</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Storage/MboxTest.php">
     <InternalMethod occurrences="3">
@@ -3428,6 +3537,10 @@
     <PossiblyInvalidIterator occurrences="1">
       <code>$ids</code>
     </PossiblyInvalidIterator>
+    <UnevaluatedCode occurrences="2">
+      <code>return;</code>
+      <code>return;</code>
+    </UnevaluatedCode>
     <UnusedVariable occurrences="5">
       <code>$content</code>
       <code>$count</code>
@@ -3659,10 +3772,6 @@
     <InvalidArgument occurrences="2">
       <code>$spec</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
-      <code>$code</code>
-      <code>$message</code>
-    </MissingClosureParamType>
     <MissingParamType occurrences="5">
       <code>$class</code>
       <code>$expectedClass</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -93,6 +93,15 @@
     <MixedArgument occurrences="1">
       <code>$value</code>
     </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$conversionInfo['errors']</code>
+    </MixedArrayAccess>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$ascii</code>
+    </MixedReturnStatement>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$format !== HeaderInterface::FORMAT_RAW</code>
     </RedundantConditionGivenDocblockType>

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -7,8 +7,6 @@ use Laminas\Mail\AddressList;
 use Laminas\Mail\Headers;
 use Laminas\Mail\Storage\Exception\RuntimeException;
 use Throwable;
-use TrueBV\Exception\OutOfBoundsException;
-use TrueBV\Punycode;
 
 /**
  * Base class for headers composing address lists (to, from, cc, bcc, reply-to)
@@ -52,11 +50,6 @@ abstract class AbstractAddressList implements HeaderInterface
      * @var string lower case field name
      */
     protected static $type;
-
-    /**
-     * @var Punycode|null
-     */
-    private static $punycode;
 
     public static function fromString($headerLine)
     {
@@ -128,11 +121,24 @@ abstract class AbstractAddressList implements HeaderInterface
      */
     protected function idnToAscii($domainName)
     {
-        if (function_exists('idn_to_ascii')) {
-            return $this->idnToAsciiViaIntl($domainName);
+        $ascii = idn_to_ascii($domainName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, $conversionInfo);
+        if (false !== $ascii) {
+            return $ascii;
         }
 
-        return $this->idnToAsciiViaPunycode($domainName);
+        $messages = [];
+        $errors   = (int) $conversionInfo['errors'];
+
+        foreach (self::IDNA_ERROR_MAP as $flag => $message) {
+            if (($flag & $errors) === $flag) {
+                $messages[] = $message;
+            }
+        }
+
+        throw new RuntimeException(sprintf(
+            'Failed encoding domain due to errors: %s',
+            implode(', ', $messages)
+        ));
     }
 
     public function getFieldValue($format = HeaderInterface::FORMAT_RAW)
@@ -266,41 +272,5 @@ abstract class AbstractAddressList implements HeaderInterface
             '',
             $value
         );
-    }
-
-    private function idnToAsciiViaIntl(string $domainName): string
-    {
-        $ascii = idn_to_ascii($domainName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, $conversionInfo);
-        if (false !== $ascii) {
-            return $ascii;
-        }
-
-        $messages = [];
-        $errors   = (int) $conversionInfo['errors'];
-
-        foreach (self::IDNA_ERROR_MAP as $flag => $message) {
-            if (($flag & $errors) === $flag) {
-                $messages[] = $message;
-            }
-        }
-
-        throw new RuntimeException(sprintf(
-            'Failed encoding domain due to errors: %s',
-            implode(', ', $messages)
-        ));
-    }
-
-    private function idnToAsciiViaPunycode(string $domainName): string
-    {
-        if (null === self::$punycode) {
-            self::$punycode = new Punycode();
-        }
-        try {
-            return self::$punycode->encode($domainName);
-        } catch (OutOfBoundsException $e) {
-            return $domainName;
-        } catch (Throwable $e) {
-            throw new RuntimeException(sprintf('Unable to convert IDN to ASCII: %s', $e->getMessage()));
-        }
     }
 }

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -119,7 +119,7 @@ abstract class AbstractAddressList implements HeaderInterface
      * @param string $domainName the UTF-8 encoded email
      * @return string
      */
-    protected function idnToAscii($domainName)
+    protected function idnToAscii($domainName): string
     {
         $ascii = idn_to_ascii($domainName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, $conversionInfo);
         if (false !== $ascii) {

--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -308,12 +308,12 @@ class Part implements RecursiveIterator, Part\PartInterface
                 if ($header instanceof HeaderInterface) {
                     $return = $header->getFieldValue(HeaderInterface::FORMAT_RAW);
                 } else {
-                    $return = '';
-                    foreach ($header as $h) {
-                        $return .= $h->getFieldValue(HeaderInterface::FORMAT_RAW)
-                                 . Mime\Mime::LINEEND;
-                    }
-                    $return = trim($return, Mime\Mime::LINEEND);
+                    $return = trim(implode(
+                        Mime\Mime::LINEEND,
+                        array_map(static function ($header): string {
+                                return $header->getFieldValue(HeaderInterface::FORMAT_RAW);
+                        }, iterator_to_array($header))
+                    ), Mime\Mime::LINEEND);
                 }
                 break;
             case 'array':

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -647,4 +647,14 @@ class HeadersTest extends TestCase
         $headers = Mail\Headers::fromString("000: foo-bar");
         $this->assertFalse($headers->get('0'));
     }
+
+    /** @group issue-175 */
+    public function testUndefinedDefineMissingIntlExtensionConstants(): void
+    {
+        $headers = Mail\Headers::fromString('To: foo@example.com')->setEncoding('UTF-8');
+
+        self::assertSame(['To' => 'foo@example.com'], $headers->toArray());
+
+        self::assertSame("To: foo@example.com" . Mail\Headers::EOL, $headers->toString());
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description


Drop `true/Punycode` in favor of `symfony/polyfill-intl-idn`

- Resolves #175
- Add failing test 
- Remove ext-intl extension for testing
- Remove missing intl extension constants and functions
- Drop `true/Punycode`
- Require `symfony/polyfill-intl-idn`
- Allow `composer/package-versions-deprecated` composer plugin
- Update composer.lock
- Update psalm-baseline.xml
