### PR TITLE
trim surrounding single quotes in emails

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -44,6 +44,8 @@ class Address implements Address\AddressInterface
             $email = $matches['email'];
         }
         $email = trim($email);
+        //trim single quotes, because outlook does add single quotes to emails sometimes which is not valid
+        $email = trim($email,'\'');
 
         return new static($email, $name, $comment);
     }


### PR DESCRIPTION
Outlook does add single quotes to emails sometimes which is not valid

|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      |no
| New Feature   |no
| RFC           | no
| QA            | no

### Description

We're seeing emails generated by outlook which do have surrounding single quote like this:
`To: <'user@example.com'>`
The fix does just trim those.
 
This is my first PR, so please let me know if did something wrong :)

