### PR TITLE
Trim surrounding single quotes in emails to support Outlook-style single-quotes around `To:` header weirdness

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -44,6 +44,8 @@ class Address implements Address\AddressInterface
             $email = $matches['email'];
         }
         $email = trim($email);
+        //trim single quotes, because outlook does add single quotes to emails sometimes which is technically not valid
+        $email = trim($email, '\'');
 
         return new static($email, $name, $comment);
     }

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -161,6 +161,25 @@ class AddressListHeaderTest extends TestCase
             ['From: (Comment\\\\)user@example.com(Another)'],
         ];
     }
+    /**
+     * @dataProvider getHeadersWithSurroundingSingleQuotes
+     */
+    public function testTrimSurroundingSingleQuotes($value): void
+    {
+        $header = To::fromString($value);
+        $list = $header->getAddressList();
+        $this->assertEquals(1, count($list));
+        $this->assertTrue($list->has('foo@example.com'));
+    }
+
+    public function getHeadersWithSurroundingSingleQuotes(): array
+    {
+        return [
+            ['To: <\'foo@example.com\'>'],
+            ['To: Foo Bar <\'foo@example.com\'>'],
+            ['To: \'foo@example.com\''],
+        ];
+    }
 
     /**
      * @group 3789

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -161,10 +161,11 @@ class AddressListHeaderTest extends TestCase
             ['From: (Comment\\\\)user@example.com(Another)'],
         ];
     }
+
     /**
      * @dataProvider getHeadersWithSurroundingSingleQuotes
      */
-    public function testTrimSurroundingSingleQuotes($value): void
+    public function testTrimSurroundingSingleQuotes(string $value): void
     {
         $header = To::fromString($value);
         $list = $header->getAddressList();
@@ -172,6 +173,9 @@ class AddressListHeaderTest extends TestCase
         $this->assertTrue($list->has('foo@example.com'));
     }
 
+    /**
+     * @return string[][]
+     */
     public function getHeadersWithSurroundingSingleQuotes(): array
     {
         return [

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -4,7 +4,7 @@ namespace LaminasTest\Mail\Storage;
 
 use Exception as GeneralException;
 use Laminas\Mail\Exception as MailException;
-use Laminas\Mail\Header\To;
+use Laminas\Mail\Header\HeaderInterface;
 use Laminas\Mail\Headers;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
@@ -52,13 +52,16 @@ class MessageTest extends TestCase
         $message = new Message($params);
         $this->assertEquals($message->subject, 'multipart');
     }
+
     /**
      * @dataProvider filesProvider
      */
-    public function testGetToHeader($params): void
+    public function testGetToHeader(array $params): void
     {
         $message = new Message($params);
-        $this->assertEquals('foo@example.com', $message->getHeader('To')->getFieldValue());
+        /** @var HeaderInterface $toHeader */
+        $toHeader = $message->getHeader('To');
+        $this->assertEquals('foo@example.com', $toHeader->getFieldValue());
     }
 
     /**

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -490,6 +490,7 @@ class MessageTest extends TestCase
     {
         $filePath = __DIR__ . '/../_files/mail.eml';
         $fileBlankLineOnTop = __DIR__ . '/../_files/mail_blank_top_line.eml';
+        $fileSurroundingSingleQuotes = __DIR__ . '/../_files/mail_surrounding_single_quotes.eml';
 
         return [
             // Description => [params]
@@ -497,7 +498,7 @@ class MessageTest extends TestCase
             'file path'                   => [['file' => $filePath]],
             'raw'                         => [['raw'  => file_get_contents($filePath)]],
             'file with blank line on top' => [['file' => $fileBlankLineOnTop]],
-            'file with surrounding single quotes' => [['file' => $fileBlankLineOnTop]],
+            'file with surrounding single quotes' => [['file' => $fileSurroundingSingleQuotes]],
         ];
     }
 }

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -4,6 +4,7 @@ namespace LaminasTest\Mail\Storage;
 
 use Exception as GeneralException;
 use Laminas\Mail\Exception as MailException;
+use Laminas\Mail\Header\To;
 use Laminas\Mail\Headers;
 use Laminas\Mail\Storage;
 use Laminas\Mail\Storage\Exception;
@@ -50,6 +51,14 @@ class MessageTest extends TestCase
     {
         $message = new Message($params);
         $this->assertEquals($message->subject, 'multipart');
+    }
+    /**
+     * @dataProvider filesProvider
+     */
+    public function testGetToHeader($params): void
+    {
+        $message = new Message($params);
+        $this->assertEquals('foo@example.com', $message->getHeader('To')->getFieldValue());
     }
 
     /**
@@ -488,6 +497,7 @@ class MessageTest extends TestCase
             'file path'                   => [['file' => $filePath]],
             'raw'                         => [['raw'  => file_get_contents($filePath)]],
             'file with blank line on top' => [['file' => $fileBlankLineOnTop]],
+            'file with surrounding single quotes' => [['file' => $fileBlankLineOnTop]],
         ];
     }
 }

--- a/test/_files/mail_surrounding_single_quotes.eml
+++ b/test/_files/mail_surrounding_single_quotes.eml
@@ -1,0 +1,27 @@
+To: <'foo@example.com'>
+Subject: multipart
+Date: Sun, 01 Jan 2000 00:00:00 +0000
+From: =?UTF-8?Q?"Peter M=C3=BCller"?= <peter-mueller@example.com>
+ContENT-type: multipart/alternative; boUNDary="crazy-multipart"
+Message-ID: <CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com>
+MIME-version: 1.0
+
+multipart message
+--crazy-multipart
+Content-type: text/plain
+
+The first part 
+is horizontal
+
+--crazy-multipart
+Content-type: text/x-vertical
+
+T s p i v
+h e a s e
+e c r   r
+  o t   t
+  n     i
+  d     c
+        a
+        l
+--crazy-multipart--


### PR DESCRIPTION
Outlook does add single quotes to emails sometimes which is not valid

|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      |no
| New Feature   |no
| RFC           | no
| QA            | no

### Description

We're seeing emails generated by outlook which do have surrounding single quote like this:
`To: <'user@example.com'>`
The fix does just trim those.

Issue on microsoft.com: https://answers.microsoft.com/en-us/outlook_com/forum/all/single-quote-marks-around-email-addresses-in/37122680-0ea2-46ed-bfeb-8f67d3441e5f
 
This is my first PR, so please let me know if did something wrong :)