### PR TITLE
Adjust documentation to avoid accumulating recipients in a loop (resulting in multiple mails received by same recipient)

### DIFF
--- a/docs/book/transport/smtp-multiple-send.md
+++ b/docs/book/transport/smtp-multiple-send.md
@@ -19,18 +19,15 @@ $transport = new Smtp([
 ]);
 
 // Create a base message:
-$template = new Message();
-$template->addFrom('sender@example.com', 'John Doe');
-$template->addReplyTo('replyto@example.com', 'Jane Doe');
-$template->setSubject('Demo of multiple mails per SMTP connection');
-$template->setBody('... Your message here ...');
+$message = (new Message())
+                ->addFrom('sender@example.com', 'John Doe')
+                ->addReplyTo('replyto@example.com', 'Jane Doe')
+                ->setSubject('Demo of multiple mails per SMTP connection')
+                ->setBody('... Your message here ...');
 
 // Loop through recipients:
 foreach ($recipients as $address) {
-    // Clone the message and add a recipient:
-    $message = clone $template;
-    $message->addTo($address);
-
+    $message->setTo($address);
     $transport->send($message);
 }
 ```


### PR DESCRIPTION
Provide a better example with changing of recipient instead of accumulating them and sending multiple times to each recipient.
Add better message instantiation and usage syntax (since PHP 5.4 !)
Remove cloning, that is unnecessary.

Fixes #189 

Signed-off-by: bouks <karibou@ribouka.com>


|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
