### PR TITLE
Exclude dev files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
+/.laminas-ci/ export-ignore
+/.laminas-ci.json export-ignore
 /.travis.yml export-ignore
 /docs/ export-ignore
 /mkdocs.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 /phpunit.xml.dist export-ignore
 /psalm-baseline.xml export-ignore
 /psalm.xml.dist export-ignore
+/renovate.json export-ignore
 /test/ export-ignore
 *.eml text eol=crlf
 *.mbox text eol=crlf


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
These files are not usefull in dist package, so I guess they could be removed.