### PR TITLE
POP3 XOAUTH2 support for Microsoft

### DIFF
--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Mail\Protocol;
 
+use Laminas\Mail\Protocol\Pop3\Response;
 use Laminas\Stdlib\ErrorHandler;
 
 class Pop3
@@ -137,6 +138,36 @@ class Pop3
      */
     public function readResponse($multiline = false)
     {
+        $response = $this->readRemoteResponse();
+
+        if ($response->status() != '+OK') {
+            throw new Exception\RuntimeException('last request failed');
+        }
+
+        $message = $response->message();
+
+        if ($multiline) {
+            $message = '';
+            $line = fgets($this->socket);
+            while ($line && rtrim($line, "\r\n") != '.') {
+                if ($line[0] == '.') {
+                    $line = substr($line, 1);
+                }
+                $message .= $line;
+                $line = fgets($this->socket);
+            }
+        }
+
+        return $message;
+    }
+
+    /**
+     * read a response
+     * return extracted status / message from response
+     * @throws Exception\RuntimeException
+     */
+    protected function readRemoteResponse(): Response
+    {
         ErrorHandler::start();
         $result = fgets($this->socket);
         $error  = ErrorHandler::stop();
@@ -152,23 +183,7 @@ class Pop3
             $message = '';
         }
 
-        if ($status != '+OK') {
-            throw new Exception\RuntimeException('last request failed');
-        }
-
-        if ($multiline) {
-            $message = '';
-            $line = fgets($this->socket);
-            while ($line && rtrim($line, "\r\n") != '.') {
-                if ($line[0] == '.') {
-                    $line = substr($line, 1);
-                }
-                $message .= $line;
-                $line = fgets($this->socket);
-            }
-        }
-
-        return $message;
+        return new Response($status, $message);
     }
 
     /**

--- a/src/Protocol/Pop3/Response.php
+++ b/src/Protocol/Pop3/Response.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Mail\Protocol\Pop3;
+
+class Response
+{
+    /** @var string $status */
+    private $status;
+
+    /** @var string $message */
+    private $message;
+
+    public function __construct(string $status, string $message)
+    {
+        $this->status = $status;
+        $this->message = $message;
+    }
+
+    public function status(): string
+    {
+        return $this->status;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Protocol/Pop3/Response.php
+++ b/src/Protocol/Pop3/Response.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Laminas\Mail\Protocol\Pop3;
 
-class Response
+/**
+ * @internal
+ * POP3 response value object
+ */
+final class Response
 {
     /** @var string $status */
     private $status;

--- a/src/Protocol/Pop3/Xoauth2/Microsoft.php
+++ b/src/Protocol/Pop3/Xoauth2/Microsoft.php
@@ -46,10 +46,11 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
      *   - port port for POP3 server [optional, default = 995]
      *   - ssl 'SSL' or 'TLS' for secure sockets
      *
-     * @param  array|object $params mail reader specific parameters
+     * @param  array $params
+     * @psalm-param array{host: non-empty-string, targetMailbox: non-empty-string, accessToken: non-empty-string, port: integer, ssl: string}
      * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
      */
-    public static function fromParams($params): self
+    public static function fromParams(array $params): self
     {
         $params = ParamsNormalizer::normalizeParams($params);
 
@@ -63,16 +64,12 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
             $port = (int) $port;
         }
 
-        if (! is_string($ssl)) {
-            $ssl = (bool) $ssl;
-        }
-
         $protocol  = new self();
 
         $protocol->connect(
             (string) $host,
             $port,
-            $ssl
+            (string) $ssl
         );
 
         $protocol->authenticate((string) $targetMailbox, (string) $accessToken);

--- a/src/Protocol/Pop3/Xoauth2/Microsoft.php
+++ b/src/Protocol/Pop3/Xoauth2/Microsoft.php
@@ -45,34 +45,28 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
      *   - accessToken from client credentials OAUTH2 flow
      *   - port port for POP3 server [optional, default = 995]
      *   - ssl 'SSL' or 'TLS' for secure sockets
-     *
-     * @param  array $params
-     * @psalm-param array{host: non-empty-string, targetMailbox: non-empty-string, accessToken: non-empty-string, port: integer, ssl: string}
+     * @param array{host: non-empty-string, targetMailbox: non-empty-string, accessToken: non-empty-string, port: int, ssl: string} $params
      * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
      */
     public static function fromParams(array $params): self
     {
         $params = ParamsNormalizer::normalizeParams($params);
 
-        $host = $params['host'] ?? 'localhost';
-        $targetMailbox = $params['targetMailbox'] ?? '';
-        $accessToken = $params['accessToken'] ?? '';
-        $port = $params['port'] ?? 995;
-        $ssl = $params['ssl'] ?? 'SSL';
-
-        if (null !== $port) {
-            $port = (int) $port;
-        }
+        $host = isset($params['host']) && is_string($params['host']) ? $params['host'] : 'localhost';
+        $targetMailbox = isset($params['targetMailbox']) && is_string($params['targetMailbox']) ? $params['targetMailbox'] : '';
+        $accessToken = isset($params['accessToken']) && is_string($params['accessToken']) ? $params['accessToken'] : '';
+        $port = isset($params['port']) && is_int($params['port']) ? $params['port'] : 995;
+        $ssl = isset($params['ssl']) && is_string($params['ssl']) ? $params['ssl'] : 'SSL';
 
         $protocol  = new self();
 
         $protocol->connect(
-            (string) $host,
+            $host,
             $port,
-            (string) $ssl
+            $ssl
         );
 
-        $protocol->authenticate((string) $targetMailbox, (string) $accessToken);
+        $protocol->authenticate($targetMailbox, $accessToken);
 
         return $protocol;
     }

--- a/src/Protocol/Pop3/Xoauth2/Microsoft.php
+++ b/src/Protocol/Pop3/Xoauth2/Microsoft.php
@@ -7,28 +7,34 @@ use Laminas\Mail\Storage\ParamsNormalizer;
 
 class Microsoft extends \Laminas\Mail\Protocol\Pop3
 {
-    public function authenticate(string $targetMailbox, string $accessToken):void
+    public function authenticate(string $targetMailbox, string $accessToken): void
     {
         $this->sendRequest('AUTH XOAUTH2');
+
         $response = $this->readRemoteResponse();
 
         if ($response->status() != '+') {
             throw new RuntimeException('last request failed');
         }
 
-        $this->request($this->buildXOauth2String($targetMailbox, $accessToken));
+        $this->request($this->buildXOauth2String(
+            $targetMailbox,
+            $accessToken
+        ));
     }
 
-    private function buildXOauth2String(string $targetMailbox, string $accessToken):string
+    private function buildXOauth2String(string $targetMailbox, string $accessToken): string
     {
-        return base64_encode(sprintf(
-            "user=%s%sauth=Bearer %s%s%s",
-            $targetMailbox,
-            chr(0x01),
-            $accessToken,
-            chr(0x01),
-            chr(0x01)
-        ));
+        return base64_encode(
+            sprintf(
+                "user=%s%sauth=Bearer %s%s%s",
+                $targetMailbox,
+                chr(0x01),
+                $accessToken,
+                chr(0x01),
+                chr(0x01)
+            )
+        );
     }
 
     /**
@@ -43,9 +49,10 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
      * @param  array|object $params mail reader specific parameters
      * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
      */
-    public static function fromParams($params):self
+    public static function fromParams($params): self
     {
         $params = ParamsNormalizer::normalizeParams($params);
+
         $host = $params['host'] ?? 'localhost';
         $targetMailbox = $params['targetMailbox'] ?? '';
         $accessToken = $params['accessToken'] ?? '';

--- a/src/Protocol/Pop3/Xoauth2/Microsoft.php
+++ b/src/Protocol/Pop3/Xoauth2/Microsoft.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laminas\Mail\Protocol\Pop3\Xoauth2;
+
+use Laminas\Mail\Protocol\Exception\RuntimeException;
+use Laminas\Mail\Storage\ParamsNormalizer;
+
+class Microsoft extends \Laminas\Mail\Protocol\Pop3
+{
+    public function authenticate($targetMailbox, $accessToken)
+    {
+        $this->sendRequest('AUTH XOAUTH2');
+        $response = $this->readRemoteResponse();
+
+        if ($response->status() != '+') {
+            throw new RuntimeException('last request failed');
+        }
+
+        $this->request($this->buildXOauth2String($targetMailbox, $accessToken));
+    }
+
+    private function buildXOauth2String(string $user, string $accessToken):string{
+        return base64_encode(sprintf(
+            "user=%s%sauth=Bearer %s%s%s",
+            $user,
+            chr(0x01),
+            $accessToken,
+            chr(0x01),
+            chr(0x01)
+        ));
+    }
+
+    /**
+     * create instance from parameters
+     * Supported parameters are
+     *   - host hostname or ip address of POP3 server
+     *   - targetMailbox mail address of the mailbox to access
+     *   - accessToken from client credentials OAUTH2 flow
+     *   - port port for POP3 server [optional, default = 995]
+     *   - ssl 'SSL' or 'TLS' for secure sockets
+     *
+     * @param  array|object $params mail reader specific parameters
+     * @throws \Laminas\Mail\Protocol\Exception\RuntimeException
+     */
+    public static function fromParams($params):self
+    {
+        $params = ParamsNormalizer::normalizeParams($params);
+        $host     = $params['host'] ?? 'localhost';
+        $targetMailbox = $params['targetMailbox'] ?? '';
+        $accessToken = $params['accessToken'] ?? '';
+        $port     = $params['port'] ?? 995;
+        $ssl      = $params['ssl'] ?? 'SSL';
+
+        if (null !== $port) {
+            $port = (int) $port;
+        }
+
+        if (! is_string($ssl)) {
+            $ssl = (bool) $ssl;
+        }
+
+        $protocol  = new self();
+
+        $protocol->connect(
+            (string) $host,
+            $port,
+            $ssl
+        );
+
+        $protocol->authenticate((string) $targetMailbox, (string) $accessToken);
+
+        return $protocol;
+    }
+}

--- a/src/Protocol/Pop3/Xoauth2/Microsoft.php
+++ b/src/Protocol/Pop3/Xoauth2/Microsoft.php
@@ -7,7 +7,7 @@ use Laminas\Mail\Storage\ParamsNormalizer;
 
 class Microsoft extends \Laminas\Mail\Protocol\Pop3
 {
-    public function authenticate($targetMailbox, $accessToken)
+    public function authenticate(string $targetMailbox, string $accessToken):void
     {
         $this->sendRequest('AUTH XOAUTH2');
         $response = $this->readRemoteResponse();
@@ -19,10 +19,11 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
         $this->request($this->buildXOauth2String($targetMailbox, $accessToken));
     }
 
-    private function buildXOauth2String(string $user, string $accessToken):string{
+    private function buildXOauth2String(string $targetMailbox, string $accessToken):string
+    {
         return base64_encode(sprintf(
             "user=%s%sauth=Bearer %s%s%s",
-            $user,
+            $targetMailbox,
             chr(0x01),
             $accessToken,
             chr(0x01),
@@ -45,11 +46,11 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
     public static function fromParams($params):self
     {
         $params = ParamsNormalizer::normalizeParams($params);
-        $host     = $params['host'] ?? 'localhost';
+        $host = $params['host'] ?? 'localhost';
         $targetMailbox = $params['targetMailbox'] ?? '';
         $accessToken = $params['accessToken'] ?? '';
-        $port     = $params['port'] ?? 995;
-        $ssl      = $params['ssl'] ?? 'SSL';
+        $port = $params['port'] ?? 995;
+        $ssl = $params['ssl'] ?? 'SSL';
 
         if (null !== $port) {
             $port = (int) $port;

--- a/src/Protocol/Pop3/Xoauth2/Microsoft.php
+++ b/src/Protocol/Pop3/Xoauth2/Microsoft.php
@@ -14,7 +14,7 @@ class Microsoft extends \Laminas\Mail\Protocol\Pop3
         $response = $this->readRemoteResponse();
 
         if ($response->status() != '+') {
-            throw new RuntimeException('last request failed');
+            throw new RuntimeException($response->message());
         }
 
         $this->request($this->buildXOauth2String(


### PR DESCRIPTION
Add support for Microsoft POP3 via modern authentication

Usage:
`$storage = new \Laminas\Mail\Storage\Pop3Pop3(\Laminas\Mail\Protocol\Pop3\Xoauth2\Microsoft::fromParams([
	'host' => 'Outlook.office365.com',
	'targetMailbox' => 'test@contoso.onmicrosoft.com',
	'accessToken' => '###ACCÈSSTOKEN###',
]));
`
