### PR TITLE
Fix field name checks for aliases in header constructors

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1589,6 +1589,67 @@
             "time": "2022-03-02T22:36:06+00:00"
         },
         {
+            "name": "fidry/cpu-core-counter",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/666cb04a02f2801f3b19955fc23c824f9018bf64",
+                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^9.5.26 || ^8.5.31",
+                "theofidry/php-cs-fixer-config": "^1.0",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-10T21:26:31+00:00"
+        },
+        {
             "name": "laminas/laminas-coding-standard",
             "version": "2.4.0",
             "source": {
@@ -1710,16 +1771,16 @@
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.16.1",
+            "version": "2.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "2bdc91a08d903fb981b451adfb8548eeb8a87c80"
+                "reference": "f382589868928e628118d80144321223944625ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/2bdc91a08d903fb981b451adfb8548eeb8a87c80",
-                "reference": "2bdc91a08d903fb981b451adfb8548eeb8a87c80",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/f382589868928e628118d80144321223944625ca",
+                "reference": "f382589868928e628118d80144321223944625ca",
                 "shasum": ""
             },
             "require": {
@@ -1777,7 +1838,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-05T18:24:57+00:00"
+            "time": "2022-12-11T12:56:04+00:00"
         },
         {
             "name": "laminas/laminas-math",
@@ -4748,16 +4809,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.1.0",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "4defa177c89397c5e14737a80fe4896584130674"
+                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/4defa177c89397c5e14737a80fe4896584130674",
-                "reference": "4defa177c89397c5e14737a80fe4896584130674",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fb685a16df3050d4c18d8a4100fe83abe6458cba",
+                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba",
                 "shasum": ""
             },
             "require": {
@@ -4776,6 +4837,7 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
+                "fidry/cpu-core-counter": "^0.4.0",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
                 "openlss/lib-array2xml": "^1.0",
@@ -4846,9 +4908,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.1.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.2.0"
             },
-            "time": "2022-12-02T01:23:35+00:00"
+            "time": "2022-12-12T08:18:56+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -1771,16 +1771,16 @@
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.16.2",
+            "version": "2.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "f382589868928e628118d80144321223944625ca"
+                "reference": "dadd9a19d2f9e89aa59205572b928892b91ff1da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/f382589868928e628118d80144321223944625ca",
-                "reference": "f382589868928e628118d80144321223944625ca",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/dadd9a19d2f9e89aa59205572b928892b91ff1da",
+                "reference": "dadd9a19d2f9e89aa59205572b928892b91ff1da",
                 "shasum": ""
             },
             "require": {
@@ -1838,7 +1838,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-11T12:56:04+00:00"
+            "time": "2022-12-17T16:31:58+00:00"
         },
         {
             "name": "laminas/laminas-math",

--- a/composer.lock
+++ b/composer.lock
@@ -1907,16 +1907,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.0.0",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
+                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
-                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
                 "shasum": ""
             },
             "require": {
@@ -1952,9 +1952,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
             },
-            "time": "2020-12-01T19:48:11+00:00"
+            "time": "2022-12-08T20:46:14+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2705,16 +2705,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.26",
+            "version": "9.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2"
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/851867efcbb6a1b992ec515c71cdcf20d895e9d2",
-                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
                 "shasum": ""
             },
             "require": {
@@ -2787,7 +2787,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.26"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
             },
             "funding": [
                 {
@@ -2803,7 +2803,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T06:00:21+00:00"
+            "time": "2022-12-09T07:31:23+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -1590,16 +1590,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64"
+                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/666cb04a02f2801f3b19955fc23c824f9018bf64",
-                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
                 "shasum": ""
             },
             "require": {
@@ -1639,7 +1639,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
             },
             "funding": [
                 {
@@ -1647,7 +1647,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-10T21:26:31+00:00"
+            "time": "2022-12-16T22:01:02+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -274,16 +274,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.28.0",
+            "version": "2.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "695bfa40b0a83dc1c5c58bdf74a03fdbeb516c39"
+                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/695bfa40b0a83dc1c5c58bdf74a03fdbeb516c39",
-                "reference": "695bfa40b0a83dc1c5c58bdf74a03fdbeb516c39",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
+                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
                 "shasum": ""
             },
             "require": {
@@ -297,17 +297,17 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-db": "^2.15.0",
-                "laminas/laminas-filter": "^2.23.0",
-                "laminas/laminas-http": "^2.17.0",
+                "laminas/laminas-db": "^2.16",
+                "laminas/laminas-filter": "^2.28.1",
+                "laminas/laminas-http": "^2.18",
                 "laminas/laminas-i18n": "^2.19",
-                "laminas/laminas-session": "^2.13.0",
+                "laminas/laminas-session": "^2.15",
                 "laminas/laminas-uri": "^2.10.0",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.18.0",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.3",
                 "psr/http-client": "^1.0.1",
                 "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^4.28"
+                "vimeo/psalm": "^5.0"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
@@ -355,7 +355,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-14T08:50:44+00:00"
+            "time": "2022-12-13T22:53:38+00:00"
         },
         {
             "name": "psr/container",
@@ -2448,16 +2448,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.19",
+            "version": "9.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
+                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
+                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
                 "shasum": ""
             },
             "require": {
@@ -2513,7 +2513,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.21"
             },
             "funding": [
                 {
@@ -2521,7 +2521,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-18T07:47:47+00:00"
+            "time": "2022-12-14T13:26:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1826,7 +1826,7 @@
       <code>$k</code>
       <code>$k</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="14">
       <code>$address</code>
       <code>$address</code>
       <code>$address</code>
@@ -1835,13 +1835,15 @@
       <code>$address</code>
       <code>$address</code>
       <code>$address</code>
+      <code>$header</code>
       <code>$header</code>
       <code>$header</code>
       <code>$list</code>
       <code>$list</code>
       <code>$v</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="6">
+    <MixedInferredReturnType occurrences="7">
+      <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -1849,7 +1851,7 @@
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="26">
+    <MixedMethodCall occurrences="28">
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -1860,6 +1862,8 @@
       <code>get</code>
       <code>getAddressList</code>
       <code>getAddressList</code>
+      <code>getFieldName</code>
+      <code>getFieldValue</code>
       <code>getName</code>
       <code>getName</code>
       <code>getName</code>
@@ -1899,7 +1903,8 @@
     <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="7">
+    <MixedInferredReturnType occurrences="8">
+      <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -1910,7 +1915,8 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/Header/ContentTransferEncodingTest.php">
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType occurrences="4">
+      <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -1933,7 +1939,8 @@
     <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType occurrences="6">
+      <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -2027,7 +2034,8 @@
     </UnusedVariable>
   </file>
   <file src="test/Header/MimeVersionTest.php">
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="3">
+      <code>array</code>
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -12,6 +12,7 @@ use function array_map;
 use function assert;
 use function idn_to_ascii;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_string;
 use function preg_match;
@@ -76,6 +77,9 @@ abstract class AbstractAddressList implements HeaderInterface
     /** @var string lower case field name */
     protected static $type;
 
+    /** @var string[] lower case aliases for the field name */
+    protected static $typeAliases = [];
+
     /**
      * @param string $headerLine
      * @return static
@@ -83,7 +87,7 @@ abstract class AbstractAddressList implements HeaderInterface
     public static function fromString($headerLine)
     {
         [$fieldName, $fieldValue] = GenericHeader::splitHeaderLine($headerLine);
-        if (strtolower($fieldName) !== static::$type) {
+        if ((strtolower($fieldName) !== static::$type) && ! in_array(strtolower($fieldName), static::$typeAliases)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid header line for "%s" string',
                 self::class

--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -8,6 +8,7 @@ use Laminas\Mime\Mime;
 use function count;
 use function explode;
 use function gettype;
+use function in_array;
 use function is_numeric;
 use function mb_strlen;
 use function mb_substr;
@@ -50,7 +51,7 @@ class ContentDisposition implements UnstructuredInterface
         $value          = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-disposition') {
+        if (! in_array(strtolower($name), ['contentdisposition', 'content_disposition', 'content-disposition'])) {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Disposition string');
         }
 

--- a/src/Header/ContentTransferEncoding.php
+++ b/src/Header/ContentTransferEncoding.php
@@ -43,7 +43,12 @@ class ContentTransferEncoding implements HeaderInterface
         $value          = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (! in_array(strtolower($name), ['contenttransferencoding', 'content_transfer_encoding', 'content-transfer-encoding'])) {
+        if (
+            ! in_array(
+                strtolower($name),
+                ['contenttransferencoding', 'content_transfer_encoding', 'content-transfer-encoding']
+            )
+        ) {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Transfer-Encoding string');
         }
 

--- a/src/Header/ContentTransferEncoding.php
+++ b/src/Header/ContentTransferEncoding.php
@@ -43,7 +43,7 @@ class ContentTransferEncoding implements HeaderInterface
         $value          = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-transfer-encoding') {
+        if (! in_array(strtolower($name), ['contenttransferencoding', 'content_transfer_encoding', 'content-transfer-encoding'])) {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Transfer-Encoding string');
         }
 

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -8,6 +8,7 @@ use Laminas\Mime\Mime;
 use function count;
 use function explode;
 use function implode;
+use function in_array;
 use function preg_match;
 use function sprintf;
 use function str_replace;
@@ -39,7 +40,7 @@ class ContentType implements UnstructuredInterface
         $value          = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-type') {
+        if (! in_array(strtolower($name), ['contenttype', 'content_type', 'content-type'])) {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Type string');
         }
 

--- a/src/Header/HeaderWrap.php
+++ b/src/Header/HeaderWrap.php
@@ -10,6 +10,8 @@ use function explode;
 use function extension_loaded;
 use function iconv_mime_decode;
 use function iconv_mime_encode;
+use function imap_mime_header_decode;
+use function imap_utf8;
 use function implode;
 use function str_contains;
 use function str_pad;

--- a/src/Header/MimeVersion.php
+++ b/src/Header/MimeVersion.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Mail\Header;
 
+use function in_array;
 use function preg_match;
 use function strtolower;
 
@@ -20,7 +21,7 @@ class MimeVersion implements HeaderInterface
         $value          = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'mime-version') {
+        if (! in_array(strtolower($name), ['mimeversion', 'mime_version', 'mime-version'])) {
             throw new Exception\InvalidArgumentException('Invalid header line for MIME-Version string');
         }
 

--- a/src/Header/ReplyTo.php
+++ b/src/Header/ReplyTo.php
@@ -8,4 +8,6 @@ class ReplyTo extends AbstractAddressList
     protected $fieldName = 'Reply-To';
     /** @var string  */
     protected static $type = 'reply-to';
+    /** @var string[] */
+    protected static $typeAliases = ['replyto', 'reply_to'];
 }

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -284,9 +284,10 @@ class AddressListHeaderTest extends TestCase
     }
 
     /**
+     * @param class-string $class
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $class, string $expected)
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $class, string $expected): void
     {
         $callback = sprintf('%s::fromString', $class);
         $header   = $callback($headerLine);

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -273,4 +273,24 @@ class AddressListHeaderTest extends TestCase
             $this->assertEquals($addressList->get($k)->getName(), $v);
         }
     }
+
+    public function unconventionalHeaderLinesProvider(): array {
+        return [
+            // Description => [header line, expected]
+            'replyto' => ['ReplyTo: test@example.com', ReplyTo::class, 'test@example.com'],
+            'reply_to' => ['Reply_To: test@example.com', ReplyTo::class, 'test@example.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider unconventionalHeaderLinesProvider
+     */
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $class, string $expected) {
+        $callback = sprintf('%s::fromString', $class);
+        $header   = $callback($headerLine);
+        $this->assertInstanceOf($class, $header);
+        $this->assertEquals('Reply-To', $header->getFieldName());
+        $this->assertEquals($expected, $header->getFieldValue());
+    }
+
 }

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -274,10 +274,11 @@ class AddressListHeaderTest extends TestCase
         }
     }
 
-    public function unconventionalHeaderLinesProvider(): array {
+    public function unconventionalHeaderLinesProvider(): array
+    {
         return [
             // Description => [header line, expected]
-            'replyto' => ['ReplyTo: test@example.com', ReplyTo::class, 'test@example.com'],
+            'replyto'  => ['ReplyTo: test@example.com', ReplyTo::class, 'test@example.com'],
             'reply_to' => ['Reply_To: test@example.com', ReplyTo::class, 'test@example.com'],
         ];
     }
@@ -285,12 +286,12 @@ class AddressListHeaderTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $class, string $expected) {
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $class, string $expected)
+    {
         $callback = sprintf('%s::fromString', $class);
         $header   = $callback($headerLine);
         $this->assertInstanceOf($class, $header);
         $this->assertEquals('Reply-To', $header->getFieldName());
         $this->assertEquals($expected, $header->getFieldValue());
     }
-
 }

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -351,7 +351,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected): void
     {
         $header = ContentDisposition::fromString($headerLine);
         $this->assertInstanceOf(ContentDisposition::class, $header);

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -339,10 +339,11 @@ class ContentDispositionTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function unconventionalHeaderLinesProvider(): array {
+    public function unconventionalHeaderLinesProvider(): array
+    {
         return [
             // Description => [header line, expected]
-            'contentdisposition' => ['Content-Disposition: inline', 'inline'],
+            'contentdisposition'  => ['Content-Disposition: inline', 'inline'],
             'content_disposition' => ['Content_Disposition: inline', 'inline'],
         ];
     }
@@ -350,11 +351,11 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    {
         $header = ContentDisposition::fromString($headerLine);
         $this->assertInstanceOf(ContentDisposition::class, $header);
         $this->assertEquals('Content-Disposition', $header->getFieldName());
         $this->assertEquals($expected, $header->getFieldValue());
     }
-
 }

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -338,4 +338,23 @@ class ContentDispositionTest extends TestCase
         ];
         // @codingStandardsIgnoreEnd
     }
+
+    public function unconventionalHeaderLinesProvider(): array {
+        return [
+            // Description => [header line, expected]
+            'contentdisposition' => ['Content-Disposition: inline', 'inline'],
+            'content_disposition' => ['Content_Disposition: inline', 'inline'],
+        ];
+    }
+
+    /**
+     * @dataProvider unconventionalHeaderLinesProvider
+     */
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+        $header = ContentDisposition::fromString($headerLine);
+        $this->assertInstanceOf(ContentDisposition::class, $header);
+        $this->assertEquals('Content-Disposition', $header->getFieldName());
+        $this->assertEquals($expected, $header->getFieldValue());
+    }
+
 }

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -183,7 +183,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected): void
     {
         $header = ContentTransferEncoding::fromString($headerLine);
         $this->assertInstanceOf(ContentTransferEncoding::class, $header);

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -170,4 +170,22 @@ class ContentTransferEncodingTest extends TestCase
         $header->setEncoding('UTF-8');
         $this->assertSame('ASCII', $header->getEncoding());
     }
+
+    public function unconventionalHeaderLinesProvider(): array {
+        return [
+            // Description => [header line, expected value]
+            'contenttransferencoding' => ['ContentTransferEncoding: 7bit', '7bit'],
+            'content_transfer_encoding' => ['Content_Transfer_Encoding: 7bit', '7bit'],
+        ];
+    }
+
+    /**
+     * @dataProvider unconventionalHeaderLinesProvider
+     */
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+        $header = ContentTransferEncoding::fromString($headerLine);
+        $this->assertInstanceOf(ContentTransferEncoding::class, $header);
+        $this->assertEquals('Content-Transfer-Encoding', $header->getFieldName());
+        $this->assertEquals($expected, $header->getFieldValue());
+    }
 }

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -171,10 +171,11 @@ class ContentTransferEncodingTest extends TestCase
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function unconventionalHeaderLinesProvider(): array {
+    public function unconventionalHeaderLinesProvider(): array
+    {
         return [
             // Description => [header line, expected value]
-            'contenttransferencoding' => ['ContentTransferEncoding: 7bit', '7bit'],
+            'contenttransferencoding'   => ['ContentTransferEncoding: 7bit', '7bit'],
             'content_transfer_encoding' => ['Content_Transfer_Encoding: 7bit', '7bit'],
         ];
     }
@@ -182,7 +183,8 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    {
         $header = ContentTransferEncoding::fromString($headerLine);
         $this->assertInstanceOf(ContentTransferEncoding::class, $header);
         $this->assertEquals('Content-Transfer-Encoding', $header->getFieldName());

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -270,4 +270,22 @@ class ContentTypeTest extends TestCase
             ['title*' => "us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A"],
         ];
     }
+
+    public function unconventionalHeaderLinesProvider(): array {
+        return [
+            // Description => [header line, expected value]
+            'contenttype' => ['ContentType: text/plain', 'text/plain'],
+            'content_type' => ['Content_Type: text/plain', 'text/plain'],
+        ];
+    }
+
+    /**
+     * @dataProvider unconventionalHeaderLinesProvider
+     */
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+        $header = ContentType::fromString($headerLine);
+        $this->assertInstanceOf(ContentType::class, $header);
+        $this->assertEquals('Content-Type', $header->getFieldName());
+        $this->assertEquals($expected, $header->getFieldValue());
+    }
 }

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -283,7 +283,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected): void
     {
         $header = ContentType::fromString($headerLine);
         $this->assertInstanceOf(ContentType::class, $header);

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -271,10 +271,11 @@ class ContentTypeTest extends TestCase
         ];
     }
 
-    public function unconventionalHeaderLinesProvider(): array {
+    public function unconventionalHeaderLinesProvider(): array
+    {
         return [
             // Description => [header line, expected value]
-            'contenttype' => ['ContentType: text/plain', 'text/plain'],
+            'contenttype'  => ['ContentType: text/plain', 'text/plain'],
             'content_type' => ['Content_Type: text/plain', 'text/plain'],
         ];
     }
@@ -282,7 +283,8 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    {
         $header = ContentType::fromString($headerLine);
         $this->assertInstanceOf(ContentType::class, $header);
         $this->assertEquals('Content-Type', $header->getFieldName());

--- a/test/Header/MimeVersionTest.php
+++ b/test/Header/MimeVersionTest.php
@@ -87,4 +87,22 @@ class MimeVersionTest extends TestCase
         $header->setEncoding('UTF-8');
         $this->assertSame('ASCII', $header->getEncoding());
     }
+
+    public function unconventionalHeaderLinesProvider(): array {
+        return [
+            // Description => [header line, expected value]
+            'mimeversion'   => ["MIMEVersion: 1.0", "1.0"],
+            'mime_version' => ["MIME_Version: 1.0", "1.0"],
+        ];
+    }
+
+    /**
+     * @dataProvider unconventionalHeaderLinesProvider
+     */
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+        $header = Header\MimeVersion::fromString($headerLine);
+        $this->assertInstanceOf(Header\MimeVersion::class, $header);
+        $this->assertEquals('MIME-Version', $header->getFieldName());
+        $this->assertEquals($expected, $header->getFieldValue());
+    }
 }

--- a/test/Header/MimeVersionTest.php
+++ b/test/Header/MimeVersionTest.php
@@ -100,7 +100,7 @@ class MimeVersionTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected): void
     {
         $header = Header\MimeVersion::fromString($headerLine);
         $this->assertInstanceOf(Header\MimeVersion::class, $header);

--- a/test/Header/MimeVersionTest.php
+++ b/test/Header/MimeVersionTest.php
@@ -88,10 +88,11 @@ class MimeVersionTest extends TestCase
         $this->assertSame('ASCII', $header->getEncoding());
     }
 
-    public function unconventionalHeaderLinesProvider(): array {
+    public function unconventionalHeaderLinesProvider(): array
+    {
         return [
             // Description => [header line, expected value]
-            'mimeversion'   => ["MIMEVersion: 1.0", "1.0"],
+            'mimeversion'  => ["MIMEVersion: 1.0", "1.0"],
             'mime_version' => ["MIME_Version: 1.0", "1.0"],
         ];
     }
@@ -99,7 +100,8 @@ class MimeVersionTest extends TestCase
     /**
      * @dataProvider unconventionalHeaderLinesProvider
      */
-    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected) {
+    public function testFromStringHandlesUnconventionalNames(string $headerLine, string $expected)
+    {
         $header = Header\MimeVersion::fromString($headerLine);
         $this->assertInstanceOf(Header\MimeVersion::class, $header);
         $this->assertEquals('MIME-Version', $header->getFieldName());


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Header constructors are improved to allow less correct header names for the sake of compatibility with HeaderLocator.
The following header names are now accepted:
- reply_to
- replyto
- content_disposition
- contentdisposition
- content_transfer_encoding
- contenttransferencoding
- content_type
- contenttype
- mime_version
- mimeversion

This list is now compatible with https://github.com/laminas/laminas-mail/blob/2.22.x/src/Header/HeaderLocator.php.

- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
Fixing a bug

- How do you reproduce it?
Receive a message via POP3 with one of the aforementioned headers present.

- What did you expect to happen?
Header to be accepted and parsed, and message object created.

- What actually happened?
Exception thrown. Even though HeaderLocator is fine with such a header name, header's constru

- Are you adding documentation?
No

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
No

- Are you fixing a BC Break?
No

- Are you adding something the library currently does not support?
No

- Are you refactoring code?
No