### PR TITLE
Added auth plugin for Xoauth2

### DIFF
--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -11,7 +11,7 @@ use function is_array;
 /**
  * Performs PLAIN authentication
  */
-class Xoauth2 extends Smtp
+final class Xoauth2 extends Smtp
 {
     /**
      * PLAIN username

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Laminas\Mail\Protocol\Smtp\Auth;
+
+use Laminas\Mail\Protocol\Smtp;
+use Laminas\Mail\Protocol\Xoauth2\Xoauth2 as Xoauth2AuthEncoder;
+
+use function array_replace_recursive;
+use function base64_encode;
+use function is_array;
+
+/**
+ * Performs PLAIN authentication
+ */
+class Xoauth2 extends Smtp
+{
+    /**
+     * PLAIN username
+     *
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * PLAIN password
+     *
+     * @var string
+     */
+    protected $accessToken;
+
+    /**
+     * @param  string $host   (Default: 127.0.0.1)
+     * @param  int    $port   (Default: null)
+     * @param  array  $config Auth-specific parameters
+     */
+    public function __construct($host = '127.0.0.1', $port = null, $config = null)
+    {
+        // Did we receive a configuration array?
+        $origConfig = $config;
+        if (is_array($host)) {
+            // Merge config array with principal array, if provided
+            if (is_array($config)) {
+                $config = array_replace_recursive($host, $config);
+            } else {
+                $config = $host;
+            }
+        }
+
+        if (is_array($config)) {
+            if (isset($config['username'])) {
+                $this->setUsername($config['username']);
+            }
+            if (isset($config['access_token'])) {
+                $this->setAccessToken($config['access_token']);
+            }
+        }
+
+        // Call parent with original arguments
+        parent::__construct($host, $port, $origConfig);
+    }
+
+    /**
+     * Perform XOAUTH2 authentication with supplied credentials
+     */
+    public function auth()
+    {
+        // Ensure AUTH has not already been initiated.
+        parent::auth();
+
+        $this->_send('AUTH XOAUTH2');
+        $this->_expect(334);
+        $this->_send(Xoauth2AuthEncoder::encodeXoauth2Sasl($this->getUsername(), $this->getAccessToken()));
+        $this->_expect(235);
+        $this->auth = true;
+    }
+
+    /**
+     * Set value for username
+     *
+     * @param  string $username
+     * @return Plain
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+        return $this;
+    }
+
+    /**
+     * Get username
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Set value for access token
+     *
+     * @param  string $token
+     * @return Plain
+     */
+    public function setAccessToken($token)
+    {
+        $this->accessToken = $token;
+        return $this;
+    }
+
+    /**
+     * Get access token
+     *
+     * @return string
+     */
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
+}

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -9,28 +9,27 @@ use function array_replace_recursive;
 use function is_array;
 
 /**
- * Performs PLAIN authentication
+ * Performs Xoauth2 authentication
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
  */
 final class Xoauth2 extends Smtp
 {
     /**
-     * PLAIN username
-     *
      * @var string
      */
     protected $username;
 
     /**
-     * PLAIN password
-     *
      * @var string
      */
     protected $accessToken;
 
     /**
-     * @param  string $host   (Default: 127.0.0.1)
-     * @param  int    $port   (Default: null)
-     * @param  array  $config Auth-specific parameters
+     *
+     * @param  string|array  $host   (Default: 127.0.0.1)
+     * @param  int|null    $port   (Default: null)
+     * @param  array|null  $config Auth-specific parameters
      */
     public function __construct($host = '127.0.0.1', $port = null, ?array $config = null)
     {
@@ -47,10 +46,10 @@ final class Xoauth2 extends Smtp
 
         if (is_array($config)) {
             if (isset($config['username'])) {
-                $this->setUsername($config['username']);
+                $this->setUsername((string) $config['username']);
             }
             if (isset($config['access_token'])) {
-                $this->setAccessToken($config['access_token']);
+                $this->setAccessToken((string) $config['access_token']);
             }
         }
 
@@ -60,6 +59,8 @@ final class Xoauth2 extends Smtp
 
     /**
      * Perform XOAUTH2 authentication with supplied credentials
+     *
+     * @return void
      */
     public function auth()
     {
@@ -67,9 +68,9 @@ final class Xoauth2 extends Smtp
         parent::auth();
 
         $this->_send('AUTH XOAUTH2');
-        $this->_expect(334);
+        $this->_expect('334');
         $this->_send(Xoauth2AuthEncoder::encodeXoauth2Sasl($this->getUsername(), $this->getAccessToken()));
-        $this->_expect(235);
+        $this->_expect('235');
         $this->auth = true;
     }
 
@@ -77,11 +78,12 @@ final class Xoauth2 extends Smtp
      * Set value for username
      *
      * @param  string $username
-     * @return Plain
+     * @return Xoauth2
      */
     public function setUsername($username)
     {
         $this->username = $username;
+        
         return $this;
     }
 
@@ -99,11 +101,12 @@ final class Xoauth2 extends Smtp
      * Set value for access token
      *
      * @param  string $token
-     * @return Plain
+     * @return Xoauth2
      */
     public function setAccessToken($token)
     {
         $this->accessToken = $token;
+        
         return $this;
     }
 

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -86,7 +86,6 @@ final class Xoauth2 extends Smtp
     public function setUsername($username)
     {
         $this->username = $username;
-        
         return $this;
     }
 
@@ -109,7 +108,6 @@ final class Xoauth2 extends Smtp
     public function setAccessToken($token)
     {
         $this->accessToken = $token;
-        
         return $this;
     }
 

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -32,7 +32,7 @@ class Xoauth2 extends Smtp
      * @param  int    $port   (Default: null)
      * @param  array  $config Auth-specific parameters
      */
-    public function __construct($host = '127.0.0.1', $port = null, $config = null)
+    public function __construct($host = '127.0.0.1', $port = null, ?array $config = null)
     {
         // Did we receive a configuration array?
         $origConfig = $config;

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -6,7 +6,6 @@ use Laminas\Mail\Protocol\Smtp;
 use Laminas\Mail\Protocol\Xoauth2\Xoauth2 as Xoauth2AuthEncoder;
 
 use function array_replace_recursive;
-use function base64_encode;
 use function is_array;
 
 /**

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -16,11 +16,15 @@ use function is_array;
 final class Xoauth2 extends Smtp
 {
     /**
+     * SMTP username
+     *
      * @var string
      */
     protected $username;
 
     /**
+     * Xoauth2 access token
+     *
      * @var string
      */
     protected $accessToken;

--- a/src/Protocol/Smtp/Auth/Xoauth2.php
+++ b/src/Protocol/Smtp/Auth/Xoauth2.php
@@ -30,10 +30,9 @@ final class Xoauth2 extends Smtp
     protected $accessToken;
 
     /**
-     *
-     * @param  string|array  $host   (Default: 127.0.0.1)
-     * @param  int|null    $port   (Default: null)
-     * @param  array|null  $config Auth-specific parameters
+     * @param string|array $host (Default: 127.0.0.1)
+     * @param int|null $port (Default: null)
+     * @param array|null $config Auth-specific parameters
      */
     public function __construct($host = '127.0.0.1', $port = null, ?array $config = null)
     {
@@ -81,7 +80,7 @@ final class Xoauth2 extends Smtp
     /**
      * Set value for username
      *
-     * @param  string $username
+     * @param string $username
      * @return Xoauth2
      */
     public function setUsername($username)
@@ -104,7 +103,7 @@ final class Xoauth2 extends Smtp
     /**
      * Set value for access token
      *
-     * @param  string $token
+     * @param string $token
      * @return Xoauth2
      */
     public function setAccessToken($token)

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -41,6 +41,8 @@ class SmtpPluginManager extends AbstractPluginManager
         'Login'   => Smtp\Auth\Login::class,
         'plain'   => Smtp\Auth\Plain::class,
         'Plain'   => Smtp\Auth\Plain::class,
+        'xoauth2' => Smtp\Auth\Xoauth2::class,
+        'Xoauth2' => Smtp\Auth\Xoauth2::class,
         'smtp'    => Smtp::class,
         'Smtp'    => Smtp::class,
         'SMTP'    => Smtp::class,
@@ -69,6 +71,7 @@ class SmtpPluginManager extends AbstractPluginManager
         Smtp\Auth\Crammd5::class => InvokableFactory::class,
         Smtp\Auth\Login::class   => InvokableFactory::class,
         Smtp\Auth\Plain::class   => InvokableFactory::class,
+        Smtp\Auth\Xoauth2::class   => InvokableFactory::class,
         Smtp::class              => InvokableFactory::class,
     ];
 

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -71,7 +71,7 @@ class SmtpPluginManager extends AbstractPluginManager
         Smtp\Auth\Crammd5::class => InvokableFactory::class,
         Smtp\Auth\Login::class   => InvokableFactory::class,
         Smtp\Auth\Plain::class   => InvokableFactory::class,
-        Smtp\Auth\Xoauth2::class   => InvokableFactory::class,
+        Smtp\Auth\Xoauth2::class => InvokableFactory::class,
         Smtp::class              => InvokableFactory::class,
     ];
 


### PR DESCRIPTION
- Are you adding something the library currently does not support?
Yes
- Why should it be added? 
So you can connect to services like Microsoft Office 365 and utilize SMTP that doesn't support legacy protocols
- What will it enable? 
Xoauth2 auth protocol for SMTP
- How will the code be used? 
via the Laminas\Mail\Protocol\SmtpPluginManager as "xoauth2" or by "connection_class" option as "xoauth2" on SmtpOptions fed into SmtpTransport in a factory

I'm sorry i don't see a develop branch. I'm new to this.