### PR TITLE
Adds static keyword to getPluginManagerMethod

### DIFF
--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -13,7 +13,7 @@ class SmtpPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    protected function getPluginManager(): SmtpPluginManager
+    protected static function getPluginManager(): SmtpPluginManager
     {
         return new SmtpPluginManager(new ServiceManager());
     }


### PR DESCRIPTION
PHPUnit Tests fail because of [BC break in ServiceManager 3.21](https://github.com/laminas/laminas-servicemanager/pull/184/files#diff-5470c7fee9ea3d84104b00ba271bfd93257384018f64b1a57e8105fc8b06ea2d)

This PR tries to fix the issue