### PR TITLE
Remove dependency on laminas-crypt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,14 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-crypt": "^3.10.0",
         "laminas/laminas-db": "^2.18",
-        "laminas/laminas-servicemanager": "^3.21",
-        "phpunit/phpunit": "^10.1.3",
+        "laminas/laminas-servicemanager": "^3.22.1",
+        "phpunit/phpunit": "^10.4.2",
         "psalm/plugin-phpunit": "^0.18.4",
-        "symfony/process": "^6.2.10",
-        "vimeo/psalm": "^5.11"
+        "symfony/process": "^6.3.4",
+        "vimeo/psalm": "^5.15"
     },
     "suggest": {
-        "laminas/laminas-crypt": "^3.10 Crammd5 support in SMTP Auth",
         "laminas/laminas-servicemanager": "^3.21 when using SMTP to deliver messages"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff7a7449f0dedf8f339662493072a3a5",
+    "content-hash": "9a47416ea44afe826a1255c43b30e03d",
     "packages": [
         {
             "name": "laminas/laminas-loader",
@@ -274,16 +274,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.40.0",
+            "version": "2.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "0474aec33a802a8081ec2523ec0a51c1e3d64b08"
+                "reference": "ca27df621e12cbd4c138dab7abf3e7e5692c582c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/0474aec33a802a8081ec2523ec0a51c1e3d64b08",
-                "reference": "0474aec33a802a8081ec2523ec0a51c1e3d64b08",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ca27df621e12cbd4c138dab7abf3e7e5692c582c",
+                "reference": "ca27df621e12cbd4c138dab7abf3e7e5692c582c",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +354,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-23T09:49:44+00:00"
+            "time": "2023-10-30T08:22:19+00:00"
         },
         {
             "name": "psr/container",
@@ -1635,70 +1635,6 @@
             "time": "2023-01-05T15:53:40+00:00"
         },
         {
-            "name": "laminas/laminas-crypt",
-            "version": "3.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-crypt.git",
-                "reference": "588375caf4d505fee90d1449e9714c912ceb5051"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-crypt/zipball/588375caf4d505fee90d1449e9714c912ceb5051",
-                "reference": "588375caf4d505fee90d1449e9714c912ceb5051",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "laminas/laminas-math": "^3.4",
-                "laminas/laminas-servicemanager": "^3.11.2",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/container": "^1.1"
-            },
-            "conflict": {
-                "zendframework/zend-crypt": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25"
-            },
-            "suggest": {
-                "ext-openssl": "Required for most features of Laminas\\Crypt"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Crypt\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Strong cryptography tools and password hashing",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "crypt",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-crypt/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-crypt/issues",
-                "rss": "https://github.com/laminas/laminas-crypt/releases.atom",
-                "source": "https://github.com/laminas/laminas-crypt"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-03-03T15:57:57+00:00"
-        },
-        {
             "name": "laminas/laminas-db",
             "version": "2.18.0",
             "source": {
@@ -1768,73 +1704,6 @@
                 }
             ],
             "time": "2023-05-05T16:22:28+00:00"
-        },
-        {
-            "name": "laminas/laminas-math",
-            "version": "3.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-math.git",
-                "reference": "3e90445828fd64308de2a600b48c3df051b3b17a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/3e90445828fd64308de2a600b48c3df051b3b17a",
-                "reference": "3e90445828fd64308de2a600b48c3df051b3b17a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-math": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "~9.5.25"
-            },
-            "suggest": {
-                "ext-bcmath": "If using the bcmath functionality",
-                "ext-gmp": "If using the gmp functionality"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Math\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Create cryptographically secure pseudo-random numbers, and manage big integers",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "math"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-math/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-math/issues",
-                "rss": "https://github.com/laminas/laminas-math/releases.atom",
-                "source": "https://github.com/laminas/laminas-math"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-10-18T09:53:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Address.php">
     <DocblockTypeContradiction>
       <code>! is_string($email)</code>
@@ -507,7 +507,6 @@
     <MixedArgumentTypeCoercion>
       <code>$from</code>
       <code>$result</code>
-      <code>$string</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code>$ids[0]</code>
@@ -609,7 +608,6 @@
       <code>$endPos</code>
     </PossiblyFalseOperand>
     <PossiblyInvalidArgument>
-      <code>$string</code>
       <code><![CDATA[$this->escapeString($old, $new)]]></code>
       <code><![CDATA[$this->escapeString($reference, $mailbox)]]></code>
       <code><![CDATA[$this->escapeString($user, $password)]]></code>
@@ -764,6 +762,15 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Protocol/Smtp/Auth/Crammd5.php">
+    <ArgumentTypeCoercion>
+      <code>$challenge</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code>! is_string($data)</code>
+      <code>! is_string($key)</code>
+      <code><![CDATA[$data === '']]></code>
+      <code><![CDATA[$key === '']]></code>
+    </DocblockTypeContradiction>
     <InvalidArgument>
       <code>235</code>
       <code>334</code>
@@ -775,9 +782,13 @@
       <code><![CDATA[$config['password']]]></code>
       <code><![CDATA[$config['username']]]></code>
     </MixedArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getPassword()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->getUsername()]]></code>
+    </PossiblyNullOperand>
     <PropertyNotSetInConstructor>
-      <code>$password</code>
-      <code>$username</code>
       <code>Crammd5</code>
       <code>Crammd5</code>
       <code>Crammd5</code>
@@ -1746,9 +1757,6 @@
     <MixedOperand>
       <code>$param</code>
     </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$header->getFieldValue(HeaderInterface::FORMAT_ENCODED)]]></code>
-    </MixedReturnStatement>
     <PossiblyFalseReference>
       <code>getFieldValue</code>
     </PossiblyFalseReference>

--- a/test/Protocol/Smtp/Auth/Crammd5Test.php
+++ b/test/Protocol/Smtp/Auth/Crammd5Test.php
@@ -2,6 +2,7 @@
 
 namespace LaminasTest\Mail\Protocol\Smtp\Auth;
 
+use Laminas\Mail\Exception\InvalidArgumentException;
 use Laminas\Mail\Protocol\Smtp\Auth\Crammd5;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -31,6 +32,32 @@ class Crammd5Test extends TestCase
         );
 
         $this->assertEquals('be56fa81a5671e0c62e00134180aae2c', $result);
+    }
+
+    public function testAnExceptionIsThrownForEmptyPassword(): void
+    {
+        $class  = new ReflectionClass(Crammd5::class);
+        $method = $class->getMethod('hmacMd5');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CramMD5 authentication requires a non-empty password');
+        $method->invokeArgs(
+            $this->auth,
+            ['', 'data']
+        );
+    }
+
+    public function testAnExceptionIsThrownForEmptyChallenge(): void
+    {
+        $class  = new ReflectionClass(Crammd5::class);
+        $method = $class->getMethod('hmacMd5');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CramMD5 authentication requires a non-empty challenge');
+        $method->invokeArgs(
+            $this->auth,
+            ['foo', '']
+        );
     }
 
     public function testUsernameAccessors(): void


### PR DESCRIPTION
Instead of requiring laminas-crypt, call `hash_hmac` directly.

A few psalm issues have been base-lined because we can't add native types without breaking BC. Also, some defensive conditions contradict doc-block types.

Subtle potential BC break here is that an exception will now be thrown if the password is empty|null, whereas previously, it would likely have been a type error.

Also see: https://github.com/laminas/laminas-crypt/pull/32

