### PR TITLE
Set type and boundary in multipart/alternative example

### DIFF
--- a/docs/book/message/attachments.md
+++ b/docs/book/message/attachments.md
@@ -115,7 +115,6 @@ $html->encoding = Mime::ENCODING_QUOTEDPRINTABLE;
 $content = new MimeMessage();
 // This order is important for email clients to properly display the correct version of the content
 $content->setParts([$text, $html]);
-$content->setType(Mime::
 
 $contentPart           = new MimePart($content->generateMessage());
 $contentPart->type     = Mime::MULTIPART_ALTERNATIVE;

--- a/docs/book/message/attachments.md
+++ b/docs/book/message/attachments.md
@@ -115,8 +115,11 @@ $html->encoding = Mime::ENCODING_QUOTEDPRINTABLE;
 $content = new MimeMessage();
 // This order is important for email clients to properly display the correct version of the content
 $content->setParts([$text, $html]);
+$content->setType(Mime::
 
-$contentPart = new MimePart($content->generateMessage());
+$contentPart           = new MimePart($content->generateMessage());
+$contentPart->type     = Mime::MULTIPART_ALTERNATIVE;
+$contentPart->boundary = $content->getMime()->boundary();
 
 $image              = new MimePart(fopen($pathToImage, 'r'));
 $image->type        = 'image/jpeg';


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The current example for creating [multipart/alternative emails with attachments](https://docs.laminas.dev/laminas-mail/message/attachments/#multipartalternative-emails-with-attachments) does not set the type on the `multipart/alternative` part correctly and - I think but do not know for sure - set the boundary properly.

The `$message->toString()` from current example:

```
Date: Fri, 17 Nov 2023 01:28:55 +0000
MIME-Version: 1.0
Content-Type: multipart/related;
 boundary="=_9d9f789a56aeae641849c009c02fa723"

This is a message in Mime Format.  If you see this, your mail reader does not support this format.

--=_9d9f789a56aeae641849c009c02fa723
Content-Type: application/octet-stream
Content-Transfer-Encoding: 8bit

This is a message in Mime Format.  If you see this, your mail reader does not support this format.

--=_4d411f45abeb9e7a0f3f37bb3d9e31a4
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable

foo
--=_4d411f45abeb9e7a0f3f37bb3d9e31a4
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

<h1>foo</h1>
--=_4d411f45abeb9e7a0f3f37bb3d9e31a4--
--=_9d9f789a56aeae641849c009c02fa723
Content-Type: image/jpeg
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="image-file-name.jpg"

Zm9v
--=_9d9f789a56aeae641849c009c02fa723--
```

Note the `Content-Type: application/octet-stream` - this should be `Content-Type: multipart/alternative`.

The correct output should be something like:

```
Date: Fri, 17 Nov 2023 01:47:10 +0000
MIME-Version: 1.0
Content-Type: multipart/related;
 boundary="=_d571c7f5c9c8e28e0a473154b2b8f5b7"

This is a message in Mime Format.  If you see this, your mail reader does not support this format.

--=_d571c7f5c9c8e28e0a473154b2b8f5b7
Content-Type: multipart/alternative;
 boundary="=_fcf2fe73fcee5fe8fdf249c81779d2c7"
Content-Transfer-Encoding: 8bit

This is a message in Mime Format.  If you see this, your mail reader does not support this format.

--=_fcf2fe73fcee5fe8fdf249c81779d2c7
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable

foo
--=_fcf2fe73fcee5fe8fdf249c81779d2c7
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

<h1>foo</h1>
--=_fcf2fe73fcee5fe8fdf249c81779d2c7--
--=_d571c7f5c9c8e28e0a473154b2b8f5b7
Content-Type: image/jpeg
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="image-file-name.jpg"

Zm9v
--=_d571c7f5c9c8e28e0a473154b2b8f5b7--
```

I happened on this while investigating https://github.com/Webador/SlmMail/pull/157. The application I'm migrating to `slm/mail` sets the type and boundary as in this PR, and has been sending emails over SMTP successfully for yonks. 

I'm not 100% sure setting the boundary is necessary. I'm not a MIME expert, but it looks suspicious to me that the first example above has the same boundary for the message as the `multipart/alternative` part. _Someone_ made the effort in the application I'm working on to explicitly set it - I suspect it was for a reason 😁 Hopefully someone here will know for sure.
