### PR TITLE
Fix for failed call to Laminas\Mail\Storage\Imap->close() on invalid server response

### DIFF
--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -169,6 +169,10 @@ class Imap
     {
         $line = $this->nextLine();
 
+        if (! str_contains($line, ' ')) {
+            throw new Exception\RuntimeException('Invalid response line received: ' . $line);
+        }
+
         // separate tag from line
         [$tag, $line] = explode(' ', $line, 2);
 
@@ -445,9 +449,10 @@ class Imap
                 $result = $this->requestAndResponse('LOGOUT', [], true);
             } catch (Exception\ExceptionInterface) {
                 // ignoring exception
+            } finally {
+                fclose($this->socket);
+                $this->socket = null;
             }
-            fclose($this->socket);
-            $this->socket = null;
         }
         return $result;
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Sometimes IMAP mail servers do not respond with valid tagged lines when issuing a logout as done in `Laminas\Mail\Protocol\Imap::logout()`. This may lead to a failure in `nextTaggedLine()` as shown below, as the response does not contain any empty spaces and the explode does not work as expected:

```
Undefined array key 1 in vendor/laminas/laminas-mail/src/Protocol/Imap.php on line 173

#0 vendor/laminas/laminas-mail/src/Protocol/Imap.php(289): Laminas\Mail\Protocol\Imap->nextTaggedLine()
#1 vendor/laminas/laminas-mail/src/Protocol/Imap.php(312): Laminas\Mail\Protocol\Imap->readLine()
#2 vendor/laminas/laminas-mail/src/Protocol/Imap.php(377): Laminas\Mail\Protocol\Imap->readResponse()
#3 vendor/laminas/laminas-mail/src/Protocol/Imap.php(445): Laminas\Mail\Protocol\Imap->requestAndResponse()
#4 vendor/laminas/laminas-mail/src/Storage/Imap.php(257): Laminas\Mail\Protocol\Imap->logout()
```

This results in the socket not being closed inside `logout()`, which in turn, leads to another exception when ```Protocol\Imap::__destruct()``` is called upon destruction, as it again attempts to issue a logout with the server because the socket variable is still set. The bugfix provided includes a check inside ```nextTaggedLine()``` to verify that the read line can be used as expected, otherwise a `RuntimeException` is thrown. Furthermore, `logout()` has been altered to always close the socket even if an uncaught exception occurs.
