### PR TITLE
Message->setBody: Clear headers when adding multi-part body

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -408,12 +408,11 @@ class Message
 
         // Multipart content headers
         if ($this->body->isMultiPart()) {
-            $mime = $this->body->getMime();
-
-            /** @var ContentType $header */
-            $header = $this->getHeaderByName('content-type', ContentType::class);
-            $header->setType('multipart/mixed');
-            $header->addParameter('boundary', $mime->boundary());
+            $this->clearHeaderByName('content-type');
+            $this->clearHeaderByName('content-transfer-encoding');
+            $this->getHeaderByName('content-type', ContentType::class)
+                ->setType('multipart/mixed')
+                ->addParameter('boundary', $this->body->getMime()->boundary());
             return $this;
         }
 


### PR DESCRIPTION
It is undesirable for the `Content-Type` and `Content-Transfer-Encoding` headers to remain from a previous single-part call. Solves #265